### PR TITLE
[ᚬrc/v0.11.0] feat: add RPC `get_block_by_number`

### DIFF
--- a/lib/ckb/api.rb
+++ b/lib/ckb/api.rb
@@ -47,7 +47,7 @@ module CKB
     end
 
     def genesis_block
-      @genesis_block ||= get_block(genesis_block_hash)
+      @genesis_block ||= get_block_by_number("0")
     end
 
     def genesis_block_hash

--- a/lib/ckb/api.rb
+++ b/lib/ckb/api.rb
@@ -62,6 +62,10 @@ module CKB
       rpc_request("get_block", params: [block_hash])
     end
 
+    def get_block_by_number(block_number)
+      rpc_request("get_block_by_number", params: [block_number.to_s])
+    end
+
     def get_tip_header
       rpc_request("get_tip_header")
     end

--- a/spec/ckb/api_spec.rb
+++ b/spec/ckb/api_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe CKB::API do
     expect(result[:header][:hash]).to eq genesis_block_hash
   end
 
+  it "get block by number" do
+    block_number = "0"
+    result = api.get_block_by_number(block_number)
+    expect(result).not_to be nil
+    expect(result[:header][:number]).to eq block_number
+  end
+
   it "get tip header" do
     result = api.get_tip_header
     expect(result).not_to be nil

--- a/spec/ckb/api_spec.rb
+++ b/spec/ckb/api_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe CKB::API do
   it "genesis block" do
     result = api.genesis_block
     expect(result).not_to be nil
+    expect(result[:header][:number]).to eq "0"
   end
 
   it "genesis block hash" do


### PR DESCRIPTION
1. add `get_block_by_number` RPC interface
2. refactor `genesis_block` to use `get_block_by_number` instead of `get_block`