### PR TITLE
Take pubkey hash(blake160) instead of pubkey as Address input

### DIFF
--- a/lib/ckb/address.rb
+++ b/lib/ckb/address.rb
@@ -2,22 +2,19 @@
 
 module CKB
   class Address
-    attr_reader :pubkey
+    attr_reader :blake160 # pubkey hash
+    alias pubkey_hash blake160
 
     PREFIX_MAINNET = "ckb"
     PREFIX_TESTNET = "ckt"
 
-    def initialize(pubkey, mode: MODE::TESTNET)
-      @pubkey = pubkey
+    def initialize(blake160, mode: MODE::TESTNET)
+      @blake160 = blake160
       @prefix = if mode == MODE::TESTNET
                   PREFIX_TESTNET
                 elsif mode == MODE::MAINNET
                   PREFIX_MAINNET
                 end
-    end
-
-    def blake160
-      @blake160 ||= self.class.blake160(@pubkey)
     end
 
     # Generates address assuming default lock script is used
@@ -47,6 +44,10 @@ module CKB
       pubkey_bin = [pubkey[2..-1]].pack("H*")
       hash_bin = CKB::Blake2b.digest(pubkey_bin)
       Utils.bin_to_hex(hash_bin[0...20])
+    end
+
+    def self.address(pubkey, mode: MODE::TESTNET)
+      new(blake160(pubkey), mode: mode)
     end
   end
 end

--- a/lib/ckb/address.rb
+++ b/lib/ckb/address.rb
@@ -46,7 +46,7 @@ module CKB
       Utils.bin_to_hex(hash_bin[0...20])
     end
 
-    def self.address(pubkey, mode: MODE::TESTNET)
+    def self.from_pubkey(pubkey, mode: MODE::TESTNET)
       new(blake160(pubkey), mode: mode)
     end
   end

--- a/lib/ckb/key.rb
+++ b/lib/ckb/key.rb
@@ -14,7 +14,7 @@ module CKB
 
       @pubkey = self.class.pubkey(@privkey)
 
-      @address = Address.new(pubkey)
+      @address = Address.address(pubkey)
     end
 
     def self.random_private_key

--- a/lib/ckb/key.rb
+++ b/lib/ckb/key.rb
@@ -14,7 +14,7 @@ module CKB
 
       @pubkey = self.class.pubkey(@privkey)
 
-      @address = Address.address(pubkey)
+      @address = Address.from_pubkey(pubkey)
     end
 
     def self.random_private_key

--- a/spec/ckb/address_spec.rb
+++ b/spec/ckb/address_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CKB::Address do
   let(:address) { "ckt1q9gry5zgxmpjnmtrp4kww5r39frh2sm89tdt2l6v234ygf" }
 
   describe "from pubkey" do
-    let(:addr) { CKB::Address.address(pubkey) }
+    let(:addr) { CKB::Address.from_pubkey(pubkey) }
 
     it "pubkey blake160" do
       addr.blake160

--- a/spec/ckb/address_spec.rb
+++ b/spec/ckb/address_spec.rb
@@ -8,26 +8,43 @@ RSpec.describe CKB::Address do
   let(:prefix) { "ckt" }
   let(:address) { "ckt1q9gry5zgxmpjnmtrp4kww5r39frh2sm89tdt2l6v234ygf" }
 
-  let(:addr) { CKB::Address.new(pubkey) }
+  describe "from pubkey" do
+    let(:addr) { CKB::Address.address(pubkey) }
 
-  it "pubkey blake160" do
-    puts "addr.blake160"
-    addr.blake160
-    pubkey_blake160
-    expect(
+    it "pubkey blake160" do
       addr.blake160
-    ).to eq pubkey_blake160
+      pubkey_blake160
+      expect(
+        addr.blake160
+      ).to eq pubkey_blake160
+    end
+
+    it "generate_address" do
+      expect(
+        addr.to_s
+      ).to eq address
+    end
+
+    it "parse_address" do
+      expect(
+        addr.parse(address)
+      ).to eq pubkey_blake160
+    end
   end
 
-  it "generate_address" do
-    expect(
-      addr.to_s
-    ).to eq address
-  end
+  describe "from pubkey hash" do
+    let(:addr) { CKB::Address.new(pubkey_blake160) }
 
-  it "parse_address" do
-    expect(
-      addr.parse(address)
-    ).to eq pubkey_blake160
+    it "generate_address" do
+      expect(
+        addr.to_s
+      ).to eq address
+    end
+
+    it "parse_address" do
+      expect(
+        addr.parse(address)
+      ).to eq pubkey_blake160
+    end
   end
 end

--- a/spec/ckb/key_spec.rb
+++ b/spec/ckb/key_spec.rb
@@ -15,4 +15,8 @@ RSpec.describe CKB::Key do
   it "pubkey" do
     expect(key.pubkey).to eq pubkey
   end
+
+  it "address" do
+    expect(key.address.to_s).to eq address
+  end
 end


### PR DESCRIPTION
BREAKING CHANGE: Address initialize requires blake160 (pubkey hash). Use Address.address(pubkey) to create address for pubkey.