### PR TITLE
[ᚬmaster] Rc/v0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.12.1](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.12.0...v0.12.1) (2019-05-18)
+# [v0.12.2](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.12.1...v0.12.2) (2019-05-21)
+
+
+### Bug Fixes
+
+* update ffi version ([b0db2c7](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/b0db2c7))
+
+
+### Features
+
+* allows sending capacity with data ([9ffd2f3](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/9ffd2f3))
+* Take pubkey hash(blake160) instead of pubkey as Address input ([3fe2fab](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/3fe2fab))
+
+
+### BREAKING CHANGES
+
+* Address initialize requires blake160 (pubkey hash). Use Address.from_pubkey(pubkey)
+to create address for pubkey.
+
+
+# [v0.12.1](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.12.0...v0.12.1) (2019-05-18)
 
 
 ### Bug Fixes
@@ -14,7 +34,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * persistent http client ([041eb60](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/041eb60))
 
 
-# [0.12.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.11.0...v0.12.0) (2019-05-18)
+# [v0.12.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.11.0...v0.12.0) (2019-05-18)
 
 
 ### Bug Fixes

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ckb-sdk-ruby.gemspec
 gemspec
+
+ruby ">= 2.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
     coderay (1.1.2)
     connection_pool (2.2.2)
     diff-lcs (1.3)
-    ffi (1.11.0)
+    ffi (1.11.1)
     jaro_winkler (1.5.2)
     method_source (0.9.2)
     net-http-persistent (3.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,5 +66,8 @@ DEPENDENCIES
   rspec (~> 3.0)
   rubocop (~> 0.66.0)
 
+RUBY VERSION
+   ruby 2.6.3p62
+
 BUNDLED WITH
    2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ckb-sdk-ruby (0.12.1)
+    ckb-sdk-ruby (0.12.2)
       bitcoin-secp256k1 (~> 0.5.0)
       net-http-persistent (~> 3.0.0)
       rbnacl (~> 6.0, >= 6.0.1)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,20 @@ Ruby SDK for CKB
 
 Require Ruby 2.4 and above.
 
-Please be noted that the SDK depends on the [bitcoin-secp256k1](https://github.com/cryptape/ruby-bitcoin-secp256k1) gem and the [rbnacl](https://github.com/crypto-rb/rbnacl) gem, which require manual install of secp256k1 and libsodium library. Follow [this](https://github.com/cryptape/ruby-bitcoin-secp256k1#prerequisite) and [this](https://github.com/crypto-rb/rbnacl#installation) to install them locally.
+Please be noted that the SDK depends on the [bitcoin-secp256k1](https://github.com/cryptape/ruby-bitcoin-secp256k1) gem and the [rbnacl](https://github.com/crypto-rb/rbnacl) gem, which require manual install of secp256k1 and libsodium library. Follow [this](https://github.com/cryptape/ruby-bitcoin-secp256k1#prerequisite) and [this](https://github.com/crypto-rb/rbnacl#installation) to install them locally. Following are examples of installing the dependencies in popular systems.
+
+### Ubuntu
+
+```bash
+sudo apt-get install libsecp256k1-dev libsodium-dev
+```
+
+### macOS
+
+```bash
+brew tap nervosnetwork/tap
+brew install libsodium libsecp256k1
+```
 
 ## Installation
 
@@ -20,7 +33,16 @@ gem 'ckb-sdk-ruby', github: 'nervosnetwork/ckb-sdk-ruby', require: 'ckb'
 
 And then execute:
 
-    $ bundle
+    $ bundle install
+
+Or if you just want to use it in a console:
+
+```
+git clone https://github.com/nervosnetwork/ckb-sdk-ruby.git
+cd ckb-sdk-ruby
+bundle install
+bin/console
+```
 
 ## Usage
 

--- a/lib/ckb/address.rb
+++ b/lib/ckb/address.rb
@@ -2,22 +2,19 @@
 
 module CKB
   class Address
-    attr_reader :pubkey
+    attr_reader :blake160 # pubkey hash
+    alias pubkey_hash blake160
 
     PREFIX_MAINNET = "ckb"
     PREFIX_TESTNET = "ckt"
 
-    def initialize(pubkey, mode: MODE::TESTNET)
-      @pubkey = pubkey
+    def initialize(blake160, mode: MODE::TESTNET)
+      @blake160 = blake160
       @prefix = if mode == MODE::TESTNET
                   PREFIX_TESTNET
                 elsif mode == MODE::MAINNET
                   PREFIX_MAINNET
                 end
-    end
-
-    def blake160
-      @blake160 ||= self.class.blake160(@pubkey)
     end
 
     # Generates address assuming default lock script is used
@@ -47,6 +44,10 @@ module CKB
       pubkey_bin = [pubkey[2..-1]].pack("H*")
       hash_bin = CKB::Blake2b.digest(pubkey_bin)
       Utils.bin_to_hex(hash_bin[0...20])
+    end
+
+    def self.from_pubkey(pubkey, mode: MODE::TESTNET)
+      new(blake160(pubkey), mode: mode)
     end
   end
 end

--- a/lib/ckb/key.rb
+++ b/lib/ckb/key.rb
@@ -14,7 +14,7 @@ module CKB
 
       @pubkey = self.class.pubkey(@privkey)
 
-      @address = Address.new(pubkey)
+      @address = Address.from_pubkey(pubkey)
     end
 
     def self.random_private_key

--- a/lib/ckb/version.rb
+++ b/lib/ckb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CKB
-  VERSION = "0.12.1"
+  VERSION = "0.12.2"
 end

--- a/lib/ckb/wallet.rb
+++ b/lib/ckb/wallet.rb
@@ -49,13 +49,14 @@ module CKB
       get_unspent_cells.map { |cell| cell.capacity.to_i }.reduce(0, &:+)
     end
 
-    def generate_tx(target_address, capacity)
+    def generate_tx(target_address, capacity, data = "0x")
       i = gather_inputs(capacity, MIN_CELL_CAPACITY)
       input_capacities = i.capacities
 
       outputs = [
         Types::Output.new(
           capacity: capacity,
+          data: data,
           lock: Types::Script.generate_lock(
             key.address.parse(target_address),
             api.system_script_code_hash
@@ -82,8 +83,9 @@ module CKB
 
     # @param target_address [String]
     # @param capacity [Integer]
-    def send_capacity(target_address, capacity)
-      tx = generate_tx(target_address, capacity)
+    # @param data [String] "0x..."
+    def send_capacity(target_address, capacity, data = "0x")
+      tx = generate_tx(target_address, capacity, data)
       send_transaction(tx)
     end
 

--- a/spec/ckb/address_spec.rb
+++ b/spec/ckb/address_spec.rb
@@ -8,26 +8,43 @@ RSpec.describe CKB::Address do
   let(:prefix) { "ckt" }
   let(:address) { "ckt1q9gry5zgxmpjnmtrp4kww5r39frh2sm89tdt2l6v234ygf" }
 
-  let(:addr) { CKB::Address.new(pubkey) }
+  describe "from pubkey" do
+    let(:addr) { CKB::Address.from_pubkey(pubkey) }
 
-  it "pubkey blake160" do
-    puts "addr.blake160"
-    addr.blake160
-    pubkey_blake160
-    expect(
+    it "pubkey blake160" do
       addr.blake160
-    ).to eq pubkey_blake160
+      pubkey_blake160
+      expect(
+        addr.blake160
+      ).to eq pubkey_blake160
+    end
+
+    it "generate_address" do
+      expect(
+        addr.to_s
+      ).to eq address
+    end
+
+    it "parse_address" do
+      expect(
+        addr.parse(address)
+      ).to eq pubkey_blake160
+    end
   end
 
-  it "generate_address" do
-    expect(
-      addr.to_s
-    ).to eq address
-  end
+  describe "from pubkey hash" do
+    let(:addr) { CKB::Address.new(pubkey_blake160) }
 
-  it "parse_address" do
-    expect(
-      addr.parse(address)
-    ).to eq pubkey_blake160
+    it "generate_address" do
+      expect(
+        addr.to_s
+      ).to eq address
+    end
+
+    it "parse_address" do
+      expect(
+        addr.parse(address)
+      ).to eq pubkey_blake160
+    end
   end
 end

--- a/spec/ckb/key_spec.rb
+++ b/spec/ckb/key_spec.rb
@@ -15,4 +15,8 @@ RSpec.describe CKB::Key do
   it "pubkey" do
     expect(key.pubkey).to eq pubkey
   end
+
+  it "address" do
+    expect(key.address.to_s).to eq address
+  end
 end


### PR DESCRIPTION
# [v0.12.2](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.12.1...v0.12.2) (2019-05-21)


### Bug Fixes

* update ffi version ([b0db2c7](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/b0db2c7))


### Features

* allows sending capacity with data ([9ffd2f3](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/9ffd2f3))
* Take pubkey hash(blake160) instead of pubkey as Address input ([3fe2fab](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/3fe2fab))


### BREAKING CHANGES

* Address initialize requires blake160 (pubkey hash). Use Address.from_pubkey(pubkey)
to create address for pubkey.