### PR TITLE
feat: Update address generator as per recent RFC 21 change

### DIFF
--- a/spec/ckb/address_spec.rb
+++ b/spec/ckb/address_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CKB::Address do
   let(:pubkey_blake160) { "0x36c329ed630d6ce750712a477543672adab57f4c" }
   let(:pubkey_blake160_bin) { Utils.hex_to_bin(pubkey_blake160) }
   let(:prefix) { "ckt" }
-  let(:address) { "ckt1q9gry5zgxmpjnmtrp4kww5r39frh2sm89tdt2l6v234ygf" }
+  let(:address) { "ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83" }
 
   context "from pubkey" do
     let(:addr) { CKB::Address.from_pubkey(pubkey) }

--- a/spec/ckb/key_spec.rb
+++ b/spec/ckb/key_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CKB::Key do
   let(:pubkey_blake160) { "0x36c329ed630d6ce750712a477543672adab57f4c" }
   let(:pubkey_blake160_bin) { Utils.hex_to_bin(pubkey_blake160) }
   let(:prefix) { "ckt" }
-  let(:address) { "ckt1q9gry5zgxmpjnmtrp4kww5r39frh2sm89tdt2l6v234ygf" }
+  let(:address) { "ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83" }
 
   let(:key) { CKB::Key.new(privkey) }
 


### PR DESCRIPTION
BREAKING CHANGE: A public key will derive different address from previous implementation.
As the code hash index has been changed from 4 bytes to 1 byte, the first serveral fixed
characters will become ckt1qyq from ckb1q9gry5zg and be shorter.

https://github.com/nervosnetwork/rfcs/pull/100