### PR TITLE
[ᚬmaster] Rc/v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [v0.20.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.19.0...v0.20.0) (2019-09-07)
+
+
+### Bug Fixes
+
+* test ([8ac5926](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/8ac5926))
+* type script serialization ([b72fe3e](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/b72fe3e))
+* wrong dep_type value ([51d5f95](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/51d5f95))
+
+
+### Features
+
+* add composite data serializers ([7783444](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/7783444))
+* add compute_hash to transaction ([7ae9c92](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/7ae9c92))
+* add compute_transaction_hash method ([d69ebf2](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/d69ebf2))
+* add transaction serialization related serializers ([4488008](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/4488008))
+* serialize script ([155c472](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/155c472))
+* update expected code_hash and type_hash ([37f0684](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/37f0684))
+* update expected code_hash and type_hash ([313ee86](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/313ee86))
+* use struct replace some table ([c5e1f17](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/c5e1f17))
+
+
 # [v0.19.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.18.0...v0.19.0) (2019-08-27)
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ckb-sdk-ruby (0.19.0)
+    ckb-sdk-ruby (0.20.0)
       bitcoin-secp256k1 (~> 0.5.2)
       net-http-persistent (~> 3.0.0)
       rbnacl (~> 6.0, >= 6.0.1)

--- a/lib/ckb.rb
+++ b/lib/ckb.rb
@@ -12,6 +12,7 @@ require "ckb/utils"
 require "ckb/wallet"
 require "ckb/address"
 require "ckb/key"
+require "ckb/serializers/serializers"
 
 module CKB
   class Error < StandardError; end

--- a/lib/ckb/api.rb
+++ b/lib/ckb/api.rb
@@ -19,8 +19,8 @@ module CKB
       @rpc = CKB::RPC.new(host: host)
       if mode == MODE::TESTNET
         # Testnet system script code_hash
-        expected_code_hash = "0x1d107ddec56ec77b79c41cd10b35a3b47434c93a604ecb8e8e73e7372fe1a794"
-        expected_type_hash = "0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88"
+        expected_code_hash = "0xa656f172b6b45c245307aeb5a7a37a176f002f6f22e92582c58bf7ba362e4176"
+        expected_type_hash = "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2"
         # For testnet chain, we can assume the second cell of the first transaction
         # in the genesis block contains default lock script we can use here.
         system_cell_transaction = genesis_block.transactions.first

--- a/lib/ckb/api.rb
+++ b/lib/ckb/api.rb
@@ -37,7 +37,7 @@ module CKB
           index: "0"
         )
 
-        secp_cell_type_hash = rpc.compute_script_hash(system_cell_transaction.outputs[1].type.to_h)
+        secp_cell_type_hash = system_cell_transaction.outputs[1].type.compute_hash
         raise "System script type_hash error!" unless secp_cell_type_hash == expected_type_hash
         set_secp_group_dep(secp_group_out_point, secp_cell_type_hash)
 

--- a/lib/ckb/serializers/arg_serializer.rb
+++ b/lib/ckb/serializers/arg_serializer.rb
@@ -21,7 +21,7 @@ module CKB
       attr_reader :bytes_serializer
 
       def layout
-        bytes_serializer.serialize
+        bytes_serializer.serialize[2..-1]
       end
     end
   end

--- a/lib/ckb/serializers/arg_serializer.rb
+++ b/lib/ckb/serializers/arg_serializer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class ArgSerializer
+      include BaseSerializer
+
+      # @param arg [String]
+      def initialize(arg)
+        if arg
+          arg = arg.start_with?("0x") ? arg[2..-1] : arg
+        else
+          arg = ""
+        end
+        items = arg.scan(/../)
+        @bytes_serializer = FixVecSerializer.new(items, ByteSerializer)
+      end
+
+      private
+
+      attr_reader :bytes_serializer
+
+      def layout
+        bytes_serializer.serialize
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/base_serializer.rb
+++ b/lib/ckb/serializers/base_serializer.rb
@@ -2,7 +2,7 @@ module CKB
   module Serializers
     module BaseSerializer
       def serialize
-        layout
+        "0x#{layout}"
       end
 
       def capacity

--- a/lib/ckb/serializers/base_serializer.rb
+++ b/lib/ckb/serializers/base_serializer.rb
@@ -1,0 +1,13 @@
+module CKB
+  module Serializers
+    module BaseSerializer
+      def serialize
+        layout
+      end
+
+      def capacity
+        [layout].pack("H*").bytesize
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/byte32_serializer.rb
+++ b/lib/ckb/serializers/byte32_serializer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class Byte32Serializer
+      include BaseSerializer
+
+      # @param value [String]
+      def initialize(value)
+        if value
+          @value = value.start_with?("0x") ? value[2..-1] : value
+        else
+          @value = ""
+        end
+      end
+
+      private
+
+      attr_reader :value
+
+      def layout
+        body
+      end
+
+      def body
+        items = value.scan(/../)
+        items.map { |item| ByteSerializer.new(item).serialize }.join("")
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/byte32_serializer.rb
+++ b/lib/ckb/serializers/byte32_serializer.rb
@@ -24,7 +24,7 @@ module CKB
 
       def body
         items = value.scan(/../)
-        items.map { |item| ByteSerializer.new(item).serialize }.join("")
+        items.map { |item| ByteSerializer.new(item).serialize[2..-1] }.join("")
       end
     end
   end

--- a/lib/ckb/serializers/byte_serializer.rb
+++ b/lib/ckb/serializers/byte_serializer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class ByteSerializer
+      include BaseSerializer
+
+      # @param value [String]
+      def initialize(value)
+        @value = value || ""
+      end
+
+      private
+
+      attr_reader :value
+
+      def layout
+        body
+      end
+
+      def body
+        value
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/capacity_serializer.rb
+++ b/lib/ckb/serializers/capacity_serializer.rb
@@ -19,7 +19,7 @@ module CKB
       end
 
       def body
-        uint64_serializer.serialize
+        uint64_serializer.serialize[2..-1]
       end
     end
   end

--- a/lib/ckb/serializers/capacity_serializer.rb
+++ b/lib/ckb/serializers/capacity_serializer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class CapacitySerializer
+      include BaseSerializer
+
+      # @param capacity [String]
+      def initialize(capacity)
+        @uint64_serializer = Uint64Serializer.new(capacity)
+      end
+
+      private
+
+      attr_reader :uint64_serializer
+
+      def layout
+        body
+      end
+
+      def body
+        uint64_serializer.serialize
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/cell_dep_serializer.rb
+++ b/lib/ckb/serializers/cell_dep_serializer.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class CellDepSerializer
+      include TableSerializer
+
+      # @param cell_dep [CKB::Types::CellDep]
+      def initialize(cell_dep)
+        @out_point_serializer = OutPointSerializer.new(cell_dep.out_point)
+        @dep_type_serializer = DepTypeSerializer.new(cell_dep.dep_type)
+        @items_count = 2
+      end
+
+      private
+
+      attr_reader :out_point_serializer, :dep_type_serializer, :items_count
+
+      def body
+        out_point_layout + dep_type_layout
+      end
+
+      def offsets
+        offset0 = (items_count + 1) * UINT32_CAPACITY
+        offset1 = offset0 + out_point_serializer.capacity
+
+        [offset0, offset1]
+      end
+
+      def out_point_layout
+        out_point_serializer.serialize
+      end
+
+      def dep_type_layout
+        dep_type_serializer.serialize
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/cell_dep_serializer.rb
+++ b/lib/ckb/serializers/cell_dep_serializer.rb
@@ -3,28 +3,20 @@
 module CKB
   module Serializers
     class CellDepSerializer
-      include TableSerializer
+      include StructSerializer
 
       # @param cell_dep [CKB::Types::CellDep]
       def initialize(cell_dep)
         @out_point_serializer = OutPointSerializer.new(cell_dep.out_point)
         @dep_type_serializer = DepTypeSerializer.new(cell_dep.dep_type)
-        @items_count = 2
       end
 
       private
 
-      attr_reader :out_point_serializer, :dep_type_serializer, :items_count
+      attr_reader :out_point_serializer, :dep_type_serializer
 
       def body
         out_point_layout + dep_type_layout
-      end
-
-      def offsets
-        offset0 = (items_count + 1) * UINT32_CAPACITY
-        offset1 = offset0 + out_point_serializer.capacity
-
-        [offset0, offset1]
       end
 
       def out_point_layout

--- a/lib/ckb/serializers/cell_dep_serializer.rb
+++ b/lib/ckb/serializers/cell_dep_serializer.rb
@@ -20,11 +20,11 @@ module CKB
       end
 
       def out_point_layout
-        out_point_serializer.serialize
+        out_point_serializer.serialize[2..-1]
       end
 
       def dep_type_layout
-        dep_type_serializer.serialize
+        dep_type_serializer.serialize[2..-1]
       end
     end
   end

--- a/lib/ckb/serializers/code_hash_serializer.rb
+++ b/lib/ckb/serializers/code_hash_serializer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class CodeHashSerializer
+      include BaseSerializer
+
+      # @param code_hash [String]
+      def initialize(code_hash)
+        @byte32_serializer = Byte32Serializer.new(code_hash)
+      end
+
+      private
+
+      attr_reader :byte32_serializer
+
+      def layout
+        body
+      end
+
+      def body
+        byte32_serializer.serialize
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/code_hash_serializer.rb
+++ b/lib/ckb/serializers/code_hash_serializer.rb
@@ -19,7 +19,7 @@ module CKB
       end
 
       def body
-        byte32_serializer.serialize
+        byte32_serializer.serialize[2..-1]
       end
     end
   end

--- a/lib/ckb/serializers/dep_type_serializer.rb
+++ b/lib/ckb/serializers/dep_type_serializer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class DepTypeSerializer
+      include BaseSerializer
+
+      # @param dep_type [String]
+      def initialize(dep_type)
+        @dep_type = dep_type
+      end
+
+      private
+
+      attr_reader :dep_type
+
+      def layout
+        body
+      end
+
+      def body
+        dep_type == "code" ? "00" : "01"
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/dyn_vec_serializer.rb
+++ b/lib/ckb/serializers/dyn_vec_serializer.rb
@@ -45,7 +45,7 @@ module CKB
       def item_layouts
         return "" if items_count == 0
 
-        items.map { |item| item_serializer.new(item).serialize }.join("")
+        items.map { |item| item_serializer.new(item).serialize[2..-1] }.join("")
       end
 
       def full_length_hex

--- a/lib/ckb/serializers/dyn_vec_serializer.rb
+++ b/lib/ckb/serializers/dyn_vec_serializer.rb
@@ -30,9 +30,13 @@ module CKB
       def offsets
         offset0 = (items_count + 1) * UINT32_CAPACITY
         offsets = []
+        previous_offset = offset0
         items.each.with_index do |_item, index|
-          offsets << offset0 and next if index == 0
-          offsets << offset0 += item_serializer.new(items[index - 1]).capacity
+          offsets << previous_offset and next if index == 0
+
+          new_offset = previous_offset + item_serializer.new(items[index - 1]).capacity
+          offsets << new_offset
+          previous_offset = new_offset
         end
 
         offsets

--- a/lib/ckb/serializers/dyn_vec_serializer.rb
+++ b/lib/ckb/serializers/dyn_vec_serializer.rb
@@ -16,11 +16,7 @@ module CKB
       attr_reader :items, :items_count, :item_serializer
 
       def layout
-        if items_count == 0
-          [UINT32_CAPACITY].pack("V").unpack1("H*")
-        else
-          header + body
-        end
+        header + body
       end
 
       def header
@@ -33,10 +29,9 @@ module CKB
 
       def offsets
         offset0 = (items_count + 1) * UINT32_CAPACITY
-        offsets = [offset0]
-        items.each.with_index(1) do |_item, index|
-          break if items[index].nil?
-
+        offsets = []
+        items.each.with_index do |_item, index|
+          offsets << offset0 and next if index == 0
           offsets << offset0 += item_serializer.new(items[index - 1]).capacity
         end
 

--- a/lib/ckb/serializers/dyn_vec_serializer.rb
+++ b/lib/ckb/serializers/dyn_vec_serializer.rb
@@ -1,0 +1,66 @@
+module CKB
+  module Serializers
+    class DynVecSerializer
+      include BaseSerializer
+
+      UINT32_CAPACITY = 4
+
+      def initialize(items, item_serializer)
+        @items = items
+        @items_count = items.count
+        @item_serializer = item_serializer
+      end
+
+      private
+
+      attr_reader :items, :items_count, :item_serializer
+
+      def layout
+        if items_count == 0
+          [UINT32_CAPACITY].pack("V").unpack1("H*")
+        else
+          header + body
+        end
+      end
+
+      def header
+        full_length_hex + offsets_hex
+      end
+
+      def body
+        item_layouts
+      end
+
+      def offsets
+        offset0 = (items_count + 1) * UINT32_CAPACITY
+        offsets = [offset0]
+        items.each.with_index(1) do |_item, index|
+          break if items[index].nil?
+
+          offsets << offset0 += item_serializer.new(items[index - 1]).capacity
+        end
+
+        offsets
+      end
+
+      def item_layouts
+        return "" if items_count == 0
+
+        items.map { |item| item_serializer.new(item).serialize }.join("")
+      end
+
+      def full_length_hex
+        full_length = (items_count + 1) * UINT32_CAPACITY + body_capacity
+        [full_length].pack("V").unpack1("H*")
+      end
+
+      def offsets_hex
+        offsets.map { |offset| [offset].pack("V").unpack1("H*") }.join("")
+      end
+
+      def body_capacity
+        [body].pack("H*").bytesize
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/fix_vec_serializer.rb
+++ b/lib/ckb/serializers/fix_vec_serializer.rb
@@ -1,0 +1,39 @@
+module CKB
+  module Serializers
+    class FixVecSerializer
+      include BaseSerializer
+
+      def initialize(items, item_serializer)
+        @items = items
+        @items_count = items.count
+        @item_serializer = item_serializer
+      end
+
+      private
+
+      attr_reader :items, :items_count, :item_serializer
+
+      def layout
+        header + body
+      end
+
+      def header
+        [items_count].pack("V").unpack1("H*")
+      end
+
+      def body
+        item_layouts
+      end
+
+      def body_capacity
+        [body].pack("H*").bytesize
+      end
+
+      def item_layouts
+        return "" if items_count == 0
+
+        items.map { |item| item_serializer.new(item).serialize }.join("")
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/fix_vec_serializer.rb
+++ b/lib/ckb/serializers/fix_vec_serializer.rb
@@ -32,7 +32,7 @@ module CKB
       def item_layouts
         return "" if items_count == 0
 
-        items.map { |item| item_serializer.new(item).serialize }.join("")
+        items.map { |item| item_serializer.new(item).serialize[2..-1] }.join("")
       end
     end
   end

--- a/lib/ckb/serializers/hash_type_serializer.rb
+++ b/lib/ckb/serializers/hash_type_serializer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class HashTypeSerializer
+      include BaseSerializer
+
+      # @param hash_type [String]
+      def initialize(hash_type)
+        @hash_type = hash_type
+      end
+
+      private
+
+      attr_reader :hash_type
+
+      def layout
+        body
+      end
+
+      def body
+        hash_type == "data" ? "00" : "01"
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/header_dep_serializer.rb
+++ b/lib/ckb/serializers/header_dep_serializer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class HeaderDepSerializer
+      include BaseSerializer
+
+      # @param header_dep [String]
+      def initialize(header_dep)
+        @byte32_serializer = Byte32Serializer.new(header_dep)
+      end
+
+      private
+
+      attr_reader :byte32_serializer
+
+      def layout
+        body
+      end
+
+      def body
+        byte32_serializer.serialize
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/header_dep_serializer.rb
+++ b/lib/ckb/serializers/header_dep_serializer.rb
@@ -19,7 +19,7 @@ module CKB
       end
 
       def body
-        byte32_serializer.serialize
+        byte32_serializer.serialize[2..-1]
       end
     end
   end

--- a/lib/ckb/serializers/input_serializer.rb
+++ b/lib/ckb/serializers/input_serializer.rb
@@ -20,11 +20,11 @@ module CKB
       end
 
       def since_layout
-        since_serializer.serialize
+        since_serializer.serialize[2..-1]
       end
 
       def out_point_layout
-        out_point_serializer.serialize
+        out_point_serializer.serialize[2..-1]
       end
     end
   end

--- a/lib/ckb/serializers/input_serializer.rb
+++ b/lib/ckb/serializers/input_serializer.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class InputSerializer
+      include TableSerializer
+
+      # @param input [CKB::Types::Input]
+      def initialize(input)
+        @out_point_serializer = OutPointSerializer.new(input.previous_output)
+        @since_serializer = SinceSerializer.new(input.since)
+        @items_count = 2
+      end
+
+      private
+
+      attr_reader :out_point_serializer, :since_serializer, :items_count
+
+      def body
+        out_point_layout + since_layout
+      end
+
+      def offsets
+        offset0 = (items_count + 1) * UINT32_CAPACITY
+        offset1 = offset0 + out_point_serializer.capacity
+
+        [offset0, offset1]
+      end
+
+      def since_layout
+        since_serializer.serialize
+      end
+
+      def out_point_layout
+        out_point_serializer.serialize
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/input_serializer.rb
+++ b/lib/ckb/serializers/input_serializer.rb
@@ -3,28 +3,20 @@
 module CKB
   module Serializers
     class InputSerializer
-      include TableSerializer
+      include StructSerializer
 
       # @param input [CKB::Types::Input]
       def initialize(input)
         @out_point_serializer = OutPointSerializer.new(input.previous_output)
         @since_serializer = SinceSerializer.new(input.since)
-        @items_count = 2
       end
 
       private
 
-      attr_reader :out_point_serializer, :since_serializer, :items_count
+      attr_reader :out_point_serializer, :since_serializer
 
       def body
-        out_point_layout + since_layout
-      end
-
-      def offsets
-        offset0 = (items_count + 1) * UINT32_CAPACITY
-        offset1 = offset0 + out_point_serializer.capacity
-
-        [offset0, offset1]
+        since_layout + out_point_layout
       end
 
       def since_layout

--- a/lib/ckb/serializers/out_point_index_serializer.rb
+++ b/lib/ckb/serializers/out_point_index_serializer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class OutPointIndexSerializer
+      include BaseSerializer
+
+      # @param index [String] number
+      def initialize(index)
+        @uint32_serializer = Uint32Serializer.new(index)
+      end
+
+      private
+
+      attr_reader :uint32_serializer
+
+      def layout
+        body
+      end
+
+      def body
+        uint32_serializer.serialize
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/out_point_index_serializer.rb
+++ b/lib/ckb/serializers/out_point_index_serializer.rb
@@ -19,7 +19,7 @@ module CKB
       end
 
       def body
-        uint32_serializer.serialize
+        uint32_serializer.serialize[2..-1]
       end
     end
   end

--- a/lib/ckb/serializers/out_point_serializer.rb
+++ b/lib/ckb/serializers/out_point_serializer.rb
@@ -21,11 +21,11 @@ module CKB
       end
 
       def index_layout
-        index_serializer.serialize
+        index_serializer.serialize[2..-1]
       end
 
       def tx_hash_layout
-        tx_hash_serializer.serialize
+        tx_hash_serializer.serialize[2..-1]
       end
     end
   end

--- a/lib/ckb/serializers/out_point_serializer.rb
+++ b/lib/ckb/serializers/out_point_serializer.rb
@@ -3,7 +3,7 @@
 module CKB
   module Serializers
     class OutPointSerializer
-      include TableSerializer
+      include StructSerializer
 
       # @param out_point [CKB::Types::OutPoint]
       def initialize(out_point)
@@ -26,13 +26,6 @@ module CKB
 
       def tx_hash_layout
         tx_hash_serializer.serialize
-      end
-
-      def offsets
-        offset0 = (items_count + 1) * UINT32_CAPACITY
-        offset1 = offset0 + BYTE32_CAPACITY
-
-        [offset0, offset1]
       end
     end
   end

--- a/lib/ckb/serializers/out_point_serializer.rb
+++ b/lib/ckb/serializers/out_point_serializer.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class OutPointSerializer
+      include TableSerializer
+
+      # @param out_point [CKB::Types::OutPoint]
+      def initialize(out_point)
+        @tx_hash_serializer = OutPointTxHashSerializer.new(out_point.tx_hash)
+        @index_serializer = OutPointIndexSerializer.new(out_point.index)
+        @items_count = 2
+      end
+
+      private
+
+      attr_reader :tx_hash_serializer, :index_serializer, :items_count
+
+      def body
+        tx_hash_layout + index_layout
+      end
+
+      def index_layout
+        index_serializer.serialize
+      end
+
+      def tx_hash_layout
+        tx_hash_serializer.serialize
+      end
+
+      def offsets
+        offset0 = (items_count + 1) * UINT32_CAPACITY
+        offset1 = offset0 + BYTE32_CAPACITY
+
+        [offset0, offset1]
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/out_point_tx_hash_serializer.rb
+++ b/lib/ckb/serializers/out_point_tx_hash_serializer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class OutPointTxHashSerializer
+      include BaseSerializer
+
+      # @param tx_hash [String]
+      def initialize(tx_hash)
+        @byte32_serializer = Byte32Serializer.new(tx_hash)
+      end
+
+      private
+
+      attr_reader :byte32_serializer
+
+      def layout
+        body
+      end
+
+      def body
+        byte32_serializer.serialize
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/out_point_tx_hash_serializer.rb
+++ b/lib/ckb/serializers/out_point_tx_hash_serializer.rb
@@ -19,7 +19,7 @@ module CKB
       end
 
       def body
-        byte32_serializer.serialize
+        byte32_serializer.serialize[2..-1]
       end
     end
   end

--- a/lib/ckb/serializers/output_data_serializer.rb
+++ b/lib/ckb/serializers/output_data_serializer.rb
@@ -21,7 +21,7 @@ module CKB
       attr_reader :bytes_serializer
 
       def layout
-        bytes_serializer.serialize
+        bytes_serializer.serialize[2..-1]
       end
     end
   end

--- a/lib/ckb/serializers/output_data_serializer.rb
+++ b/lib/ckb/serializers/output_data_serializer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class OutputDataSerializer
+      include BaseSerializer
+
+      # @param output_data [String]
+      def initialize(output_data)
+        if output_data
+          output_data = output_data.start_with?("0x") ? output_data[2..-1] : output_data
+        else
+          output_data = ""
+        end
+        items = output_data.scan(/../)
+        @bytes_serializer = FixVecSerializer.new(items, ByteSerializer)
+      end
+
+      private
+
+      attr_reader :bytes_serializer
+
+      def layout
+        bytes_serializer.serialize
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/output_serializer.rb
+++ b/lib/ckb/serializers/output_serializer.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class OutputSerializer
+      include TableSerializer
+
+      # @param output [CKB::Types::Output]
+      def initialize(output)
+        @capacity_serializer = CapacitySerializer.new(output.capacity)
+        @lock_script_serializer = ScriptSerializer.new(output.lock)
+        @type_script_serializer = ScriptSerializer.new(output.type) if output.type
+        @items_count = 3
+      end
+
+      private
+
+      attr_reader :capacity_serializer, :lock_script_serializer, :type_script_serializer, :items_count
+
+      def layout
+        header + body
+      end
+
+      def body
+        result = capacity_layout + lock_script_layout
+        result += type_script_layout if type_script_serializer
+
+        result
+      end
+
+      def type_script_layout
+        type_script_serializer.serialize
+      end
+
+      def lock_script_layout
+        lock_script_serializer.serialize
+      end
+
+      def capacity_layout
+        capacity_serializer.serialize
+      end
+
+      def offsets
+        offset0 = (items_count + 1) * UINT32_CAPACITY
+        offset1 = offset0 + UINT64_CAPACITY
+        offset2 = offset1 + lock_script_serializer.capacity
+
+        [offset0, offset1, offset2]
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/output_serializer.rb
+++ b/lib/ckb/serializers/output_serializer.rb
@@ -29,15 +29,15 @@ module CKB
       end
 
       def type_script_layout
-        type_script_serializer.serialize
+        type_script_serializer.serialize[2..-1]
       end
 
       def lock_script_layout
-        lock_script_serializer.serialize
+        lock_script_serializer.serialize[2..-1]
       end
 
       def capacity_layout
-        capacity_serializer.serialize
+        capacity_serializer.serialize[2..-1]
       end
 
       def offsets

--- a/lib/ckb/serializers/raw_transaction_serializer.rb
+++ b/lib/ckb/serializers/raw_transaction_serializer.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class RawTransactionSerializer
+      include TableSerializer
+
+      # @param transaction [CKB::Types::Transaction]
+      def initialize(transaction)
+        @version_serializer = VersionSerializer.new(transaction.version)
+        @cell_deps_serializer = DynVecSerializer.new(transaction.cell_deps, CellDepSerializer)
+        @header_deps_serializer = FixVecSerializer.new(transaction.header_deps, HeaderDepSerializer)
+        @inputs_serializer = DynVecSerializer.new(transaction.inputs, InputSerializer)
+        @outputs_serializer = DynVecSerializer.new(transaction.outputs, OutputSerializer)
+        @outputs_data_serializer = DynVecSerializer.new(transaction.outputs_data, OutputDataSerializer)
+        @items_count = 6
+      end
+
+      private
+
+      attr_reader :version_serializer, :cell_deps_serializer, :header_deps_serializer, :inputs_serializer, :outputs_serializer, :outputs_data_serializer, :items_count
+
+      def body
+        version_layout + cell_deps_layout + header_deps_layout + inputs_layout + outputs_layout + outputs_data_layout
+      end
+
+      def offsets
+        offset0 = (items_count + 1) * UINT32_CAPACITY
+        offset1 = offset0 + UINT32_CAPACITY
+        offset2 = offset1 + cell_deps_capacity
+        offset3 = offset2 + header_deps_capacity
+        offset4 = offset3 + inputs_capacity
+        offset5 = offset4 + outputs_capacity
+
+        [offset0, offset1, offset2, offset3, offset4, offset5]
+      end
+
+      def version_layout
+        version_serializer.serialize
+      end
+
+      def cell_deps_layout
+        cell_deps_serializer.serialize
+      end
+
+      def cell_deps_capacity
+        cell_deps_serializer.capacity
+      end
+
+      def header_deps_layout
+        header_deps_serializer.serialize
+      end
+
+      def header_deps_capacity
+        [header_deps_layout].pack("H*").bytesize
+      end
+
+      def inputs_layout
+        inputs_serializer.serialize
+      end
+
+      def inputs_capacity
+        inputs_serializer.capacity
+      end
+
+      def outputs_layout
+        outputs_serializer.serialize
+      end
+
+      def outputs_capacity
+        outputs_serializer.capacity
+      end
+
+      def outputs_data_layout
+        outputs_data_serializer.serialize
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/raw_transaction_serializer.rb
+++ b/lib/ckb/serializers/raw_transaction_serializer.rb
@@ -36,11 +36,11 @@ module CKB
       end
 
       def version_layout
-        version_serializer.serialize
+        version_serializer.serialize[2..-1]
       end
 
       def cell_deps_layout
-        cell_deps_serializer.serialize
+        cell_deps_serializer.serialize[2..-1]
       end
 
       def cell_deps_capacity
@@ -48,7 +48,7 @@ module CKB
       end
 
       def header_deps_layout
-        header_deps_serializer.serialize
+        header_deps_serializer.serialize[2..-1]
       end
 
       def header_deps_capacity
@@ -56,7 +56,7 @@ module CKB
       end
 
       def inputs_layout
-        inputs_serializer.serialize
+        inputs_serializer.serialize[2..-1]
       end
 
       def inputs_capacity
@@ -64,7 +64,7 @@ module CKB
       end
 
       def outputs_layout
-        outputs_serializer.serialize
+        outputs_serializer.serialize[2..-1]
       end
 
       def outputs_capacity
@@ -72,7 +72,7 @@ module CKB
       end
 
       def outputs_data_layout
-        outputs_data_serializer.serialize
+        outputs_data_serializer.serialize[2..-1]
       end
     end
   end

--- a/lib/ckb/serializers/raw_transaction_serializer.rb
+++ b/lib/ckb/serializers/raw_transaction_serializer.rb
@@ -8,9 +8,9 @@ module CKB
       # @param transaction [CKB::Types::Transaction]
       def initialize(transaction)
         @version_serializer = VersionSerializer.new(transaction.version)
-        @cell_deps_serializer = DynVecSerializer.new(transaction.cell_deps, CellDepSerializer)
+        @cell_deps_serializer = FixVecSerializer.new(transaction.cell_deps, CellDepSerializer)
         @header_deps_serializer = FixVecSerializer.new(transaction.header_deps, HeaderDepSerializer)
-        @inputs_serializer = DynVecSerializer.new(transaction.inputs, InputSerializer)
+        @inputs_serializer = FixVecSerializer.new(transaction.inputs, InputSerializer)
         @outputs_serializer = DynVecSerializer.new(transaction.outputs, OutputSerializer)
         @outputs_data_serializer = DynVecSerializer.new(transaction.outputs_data, OutputDataSerializer)
         @items_count = 6

--- a/lib/ckb/serializers/script_serializer.rb
+++ b/lib/ckb/serializers/script_serializer.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class ScriptSerializer
+      include TableSerializer
+
+      # @param script [CKB::Types::Script]
+      def initialize(script)
+        @code_hash_serializer = CodeHashSerializer.new(script.code_hash)
+        @hash_type_serializer = HashTypeSerializer.new(script.hash_type)
+        @args_serializer = DynVecSerializer.new(script.args, ArgSerializer)
+        @items_count = 3
+      end
+
+      private
+
+      attr_reader :code_hash_serializer, :hash_type_serializer, :args_serializer, :items_count
+
+      def body
+        code_hash_layout + hash_type_layout + args_layout
+      end
+
+      def offsets
+        script_offset0 = (items_count + 1) * UINT32_CAPACITY
+        script_offset1 = script_offset0 + BYTE32_CAPACITY
+        script_offset2 = script_offset1 + SCRIPT_HASH_TYPE_CAPACITY
+
+        [script_offset0, script_offset1, script_offset2]
+      end
+
+      def code_hash_layout
+        code_hash_serializer.serialize
+      end
+
+      def hash_type_layout
+        hash_type_serializer.serialize
+      end
+
+      def args_layout
+        args_serializer.serialize
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/script_serializer.rb
+++ b/lib/ckb/serializers/script_serializer.rb
@@ -30,15 +30,15 @@ module CKB
       end
 
       def code_hash_layout
-        code_hash_serializer.serialize
+        code_hash_serializer.serialize[2..-1]
       end
 
       def hash_type_layout
-        hash_type_serializer.serialize
+        hash_type_serializer.serialize[2..-1]
       end
 
       def args_layout
-        args_serializer.serialize
+        args_serializer.serialize[2..-1]
       end
     end
   end

--- a/lib/ckb/serializers/serializers.rb
+++ b/lib/ckb/serializers/serializers.rb
@@ -3,6 +3,7 @@
 require_relative "base_serializer"
 require_relative "fix_vec_serializer"
 require_relative "dyn_vec_serializer"
+require_relative "struct_serializer"
 require_relative "table_serializer"
 require_relative "uint32_serializer"
 require_relative "uint64_serializer"

--- a/lib/ckb/serializers/serializers.rb
+++ b/lib/ckb/serializers/serializers.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative "base_serializer"
+require_relative "fix_vec_serializer"
+require_relative "dyn_vec_serializer"
+require_relative "table_serializer"
+require_relative "uint32_serializer"
+require_relative "uint64_serializer"
+require_relative "byte32_serializer"
+require_relative "byte_serializer"
+require_relative "code_hash_serializer"
+require_relative "hash_type_serializer"
+require_relative "arg_serializer"
+require_relative "script_serializer"
+require_relative "version_serializer"
+require_relative "header_dep_serializer"
+require_relative "dep_type_serializer"
+require_relative "cell_dep_serializer"
+require_relative "since_serializer"
+require_relative "input_serializer"
+require_relative "capacity_serializer"
+require_relative "output_serializer"
+require_relative "out_point_tx_hash_serializer"
+require_relative "out_point_index_serializer"
+require_relative "out_point_serializer"
+require_relative "output_data_serializer"
+require_relative "raw_transaction_serializer"
+
+module CKB
+  module Serializers
+  end
+end

--- a/lib/ckb/serializers/since_serializer.rb
+++ b/lib/ckb/serializers/since_serializer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class SinceSerializer
+      include BaseSerializer
+
+      # @param since [String]
+      def initialize(since)
+        @uint64_serializer = Uint64Serializer.new(since)
+      end
+
+      private
+
+      attr_reader :uint64_serializer
+
+      def layout
+        body
+      end
+
+      def body
+        uint64_serializer.serialize
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/since_serializer.rb
+++ b/lib/ckb/serializers/since_serializer.rb
@@ -19,7 +19,7 @@ module CKB
       end
 
       def body
-        uint64_serializer.serialize
+        uint64_serializer.serialize[2..-1]
       end
     end
   end

--- a/lib/ckb/serializers/struct_serializer.rb
+++ b/lib/ckb/serializers/struct_serializer.rb
@@ -1,0 +1,13 @@
+module CKB
+  module Serializers
+    module StructSerializer
+      include BaseSerializer
+
+      private
+
+      def layout
+        body
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/table_serializer.rb
+++ b/lib/ckb/serializers/table_serializer.rb
@@ -1,0 +1,35 @@
+module CKB
+  module Serializers
+    module TableSerializer
+      include BaseSerializer
+
+      UINT32_CAPACITY = 4
+      UINT64_CAPACITY = 8
+      BYTE32_CAPACITY = 32
+      SCRIPT_HASH_TYPE_CAPACITY = 1
+
+      private
+
+      def layout
+        header + body
+      end
+
+      def header
+        full_length_hex + offsets_hex
+      end
+
+      def full_length_hex
+        full_length = (items_count + 1) * UINT32_CAPACITY + body_capacity
+        [full_length].pack("V").unpack1("H*")
+      end
+
+      def offsets_hex
+        offsets.map { |offset| [offset].pack("V").unpack1("H*") }.join("")
+      end
+
+      def body_capacity
+        [body].pack("H*").bytesize
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/uint32_serializer.rb
+++ b/lib/ckb/serializers/uint32_serializer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class Uint32Serializer
+      include BaseSerializer
+
+      # @param value [String]
+      def initialize(value)
+        @value = value
+      end
+
+      private
+
+      attr_reader :value
+
+      def layout
+        body
+      end
+
+      def body
+        [value.to_i].pack("V").unpack1("H*")
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/uint64_serializer.rb
+++ b/lib/ckb/serializers/uint64_serializer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class Uint64Serializer
+      include BaseSerializer
+
+      # @param value [String]
+      def initialize(value)
+        @value = value
+      end
+
+      private
+
+      attr_reader :value
+
+      def layout
+        body
+      end
+
+      def body
+        [value.to_i].pack("Q<").unpack1("H*")
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/version_serializer.rb
+++ b/lib/ckb/serializers/version_serializer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module CKB
+  module Serializers
+    class VersionSerializer
+      include BaseSerializer
+
+      # @param version [String]
+      def initialize(version)
+        @uint32_serializer = Uint32Serializer.new(version)
+      end
+
+      private
+
+      attr_reader :uint32_serializer
+
+      def layout
+        body
+      end
+
+      def body
+        uint32_serializer.serialize
+      end
+    end
+  end
+end

--- a/lib/ckb/serializers/version_serializer.rb
+++ b/lib/ckb/serializers/version_serializer.rb
@@ -19,7 +19,7 @@ module CKB
       end
 
       def body
-        uint32_serializer.serialize
+        uint32_serializer.serialize[2..-1]
       end
     end
   end

--- a/lib/ckb/types/output.rb
+++ b/lib/ckb/types/output.rb
@@ -3,19 +3,17 @@
 module CKB
   module Types
     class Output
-      attr_accessor :lock, :type, :out_point, :data
+      attr_accessor :lock, :type, :out_point
       attr_reader :capacity
 
       # @param capacity [String]
-      # @param data: [String] 0x...
       # @param lock [CKB::Types::Script]
       # @param type [CKB::Types::Script | nil]
       # @param out_point [CKB::Types::OutPoint | nil]
-      def initialize(capacity:, lock:, type: nil, out_point: nil, data: "0x")
+      def initialize(capacity:, lock:, type: nil, out_point: nil)
         @capacity = capacity.to_s
         @lock = lock
         @type = type
-        @data = data
         @out_point = out_point
       end
 
@@ -23,15 +21,16 @@ module CKB
         @capacity = value.to_s
       end
 
-      def calculate_bytesize
-        raise "Don't know data" if @data.nil?
-        bytesize = 8 + Utils.hex_to_bin(@data).bytesize + @lock.calculate_bytesize
+      # @param data [String] 0x...
+      def calculate_bytesize(data)
+        raise "Please provide a valid data" if data.nil?
+        bytesize = 8 + Utils.hex_to_bin(data).bytesize + @lock.calculate_bytesize
         bytesize += @type.calculate_bytesize if @type
         bytesize
       end
 
-      def calculate_min_capacity
-        Utils.byte_to_shannon(calculate_bytesize)
+      def calculate_min_capacity(data)
+        Utils.byte_to_shannon(calculate_bytesize(data))
       end
 
       def to_h

--- a/lib/ckb/types/script.rb
+++ b/lib/ckb/types/script.rb
@@ -38,8 +38,12 @@ module CKB
         )
       end
 
-      def to_hash(api)
-        api.compute_script_hash(self)
+      def compute_hash
+        script_serializer = CKB::Serializers::ScriptSerializer.new(self)
+        blake2b = CKB::Blake2b.new
+        blake2b << Utils.hex_to_bin("0x#{script_serializer.serialize}")
+
+        blake2b.hexdigest
       end
 
       def self.generate_lock(target_pubkey_blake160, secp_cell_type_hash, hash_type = "type")

--- a/lib/ckb/types/script.rb
+++ b/lib/ckb/types/script.rb
@@ -41,7 +41,7 @@ module CKB
       def compute_hash
         script_serializer = CKB::Serializers::ScriptSerializer.new(self)
         blake2b = CKB::Blake2b.new
-        blake2b << Utils.hex_to_bin("0x#{script_serializer.serialize}")
+        blake2b << Utils.hex_to_bin(script_serializer.serialize)
 
         blake2b.hexdigest
       end

--- a/lib/ckb/types/transaction.rb
+++ b/lib/ckb/types/transaction.rb
@@ -79,7 +79,7 @@ module CKB
       def compute_hash
         raw_transaction_serializer = CKB::Serializers::RawTransactionSerializer.new(self)
         blake2b = CKB::Blake2b.new
-        blake2b << Utils.hex_to_bin("0x#{raw_transaction_serializer.serialize}")
+        blake2b << Utils.hex_to_bin(raw_transaction_serializer.serialize)
         blake2b.hexdigest
       end
 

--- a/lib/ckb/types/transaction.rb
+++ b/lib/ckb/types/transaction.rb
@@ -76,6 +76,13 @@ module CKB
         hash
       end
 
+      def compute_hash
+        raw_transaction_serializer = CKB::Serializers::RawTransactionSerializer.new(self)
+        blake2b = CKB::Blake2b.new
+        blake2b << Utils.hex_to_bin("0x#{raw_transaction_serializer.serialize}")
+        blake2b.hexdigest
+      end
+
       def self.from_h(hash)
         return if hash.nil?
 

--- a/lib/ckb/version.rb
+++ b/lib/ckb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CKB
-  VERSION = "0.19.0"
+  VERSION = "0.20.0"
 end

--- a/lib/ckb/wallet.rb
+++ b/lib/ckb/wallet.rb
@@ -120,9 +120,7 @@ module CKB
         witnesses: i.witnesses
       )
 
-      tx_hash = api.compute_transaction_hash(tx)
-
-      tx.sign(key, tx_hash)
+      tx.sign(key, tx.compute_hash)
     end
 
     # @param target_address [String]
@@ -186,7 +184,7 @@ module CKB
         witnesses: i.witnesses
       )
 
-      tx_hash = api.compute_transaction_hash(tx)
+      tx_hash = tx.compute_hash
       send_transaction(tx.sign(key, tx_hash))
 
       Types::OutPoint.new(tx_hash: tx_hash, index: "0")
@@ -251,8 +249,7 @@ module CKB
           Types::Witness.new(data: ["0x0000000000000000"])
         ]
       )
-      tx_hash = api.compute_transaction_hash(tx)
-      tx.sign(key, tx_hash)
+      tx.sign(key, tx.compute_hash)
     end
 
     # @param hash_hex [String] "0x..."
@@ -271,7 +268,7 @@ args = #{lock.args}
     end
 
     def lock_hash
-      @lock_hash ||= lock.to_hash(api)
+      @lock_hash ||= lock.compute_hash
     end
 
     # @return [CKB::Types::Script]

--- a/lib/ckb/wallet.rb
+++ b/lib/ckb/wallet.rb
@@ -52,8 +52,10 @@ module CKB
         cells = api.get_cells_by_lock_hash(lock_hash, current_from.to_s, current_to.to_s)
         if skip_data_and_type
           cells.each do |cell|
-            output = api.get_live_cell(cell.out_point).cell
-            results << cell if (output.data.nil? || output.data == "0x") && output.type.nil?
+            tx = api.get_transaction(cell.out_point.tx_hash).transaction
+            output = tx.outputs[cell.out_point.index.to_i]
+            output_data = tx.outputs_data[cell.out_point.index.to_i]
+            results << cell if (output_data.nil? || output_data == "0x") && output.type.nil?
           end
         else
           results.concat(cells)
@@ -77,30 +79,35 @@ module CKB
 
       output = Types::Output.new(
         capacity: capacity,
-        data: data,
         lock: Types::Script.generate_lock(
           addr.parse(target_address),
           api.secp_cell_type_hash,
           "type"
         )
       )
+      output_data = data
 
       change_output = Types::Output.new(
         capacity: 0,
         lock: lock
       )
+      change_output_data = "0x"
 
       i = gather_inputs(
         capacity,
-        output.calculate_min_capacity,
-        change_output.calculate_min_capacity,
+        output.calculate_min_capacity(output_data),
+        change_output.calculate_min_capacity(change_output_data),
         fee
       )
       input_capacities = i.capacities
 
       outputs = [output]
+      outputs_data = [output_data]
       change_output.capacity = input_capacities - (capacity + fee)
-      outputs << change_output if change_output.capacity.to_i > 0
+      if change_output.capacity.to_i > 0
+        outputs << change_output
+        outputs_data << change_output_data
+      end
 
       tx = Types::Transaction.new(
         version: 0,
@@ -109,7 +116,7 @@ module CKB
         ],
         inputs: i.inputs,
         outputs: outputs,
-        outputs_data: outputs.map(&:data),
+        outputs_data: outputs_data,
         witnesses: i.witnesses
       )
 
@@ -143,23 +150,29 @@ module CKB
           args: []
         )
       )
+      output_data = "0x"
 
       change_output = Types::Output.new(
         capacity: 0,
         lock: lock
       )
+      change_output_data = "0x"
 
       i = gather_inputs(
         capacity,
-        output.calculate_min_capacity,
-        change_output.calculate_min_capacity,
+        output.calculate_min_capacity(output_data),
+        change_output.calculate_min_capacity(change_output_data),
         0
       )
       input_capacities = i.capacities
 
       outputs = [output]
+      outputs_data = [output_data]
       change_output.capacity = input_capacities - capacity
-      outputs << change_output if change_output.capacity.to_i > 0
+      if change_output.capacity.to_i > 0
+        outputs << change_output
+        outputs_data << change_output_data
+      end
 
       tx = Types::Transaction.new(
         version: 0,
@@ -169,7 +182,7 @@ module CKB
         ],
         inputs: i.inputs,
         outputs: outputs,
-        outputs_data: outputs.map(&:data),
+        outputs_data: outputs_data,
         witnesses: i.witnesses
       )
 
@@ -218,6 +231,7 @@ module CKB
       outputs = [
         Types::Output.new(capacity: output_capacity, lock: lock)
       ]
+      outputs_data = ["0x"]
       tx = Types::Transaction.new(
         version: 0,
         cell_deps: [
@@ -232,7 +246,7 @@ module CKB
           Types::Input.new(previous_output: new_out_point, since: since)
         ],
         outputs: outputs,
-        outputs_data: outputs.map(&:data),
+        outputs_data: outputs_data,
         witnesses: [
           Types::Witness.new(data: ["0x0000000000000000"])
         ]

--- a/spec/ckb/types/output_spec.rb
+++ b/spec/ckb/types/output_spec.rb
@@ -12,14 +12,13 @@ RSpec.describe CKB::Types::Output do
   context "calculate bytesize" do
     it "default" do
       expect(
-        output.calculate_bytesize
+        output.calculate_bytesize("0x")
       ).to eq 61
     end
 
     it "with data" do
-      output.instance_variable_set(:@data, "0x1234")
       expect(
-        output.calculate_bytesize
+        output.calculate_bytesize("0x1234")
       ).to eq 63
     end
 
@@ -31,14 +30,14 @@ RSpec.describe CKB::Types::Output do
       output.instance_variable_set(:@type, type_script)
 
       expect(
-        output.calculate_bytesize
+        output.calculate_bytesize("0x")
       ).to eq (61 + 33)
     end
   end
 
   it "calculate min capacity" do
     expect(
-      output.calculate_min_capacity
+      output.calculate_min_capacity("0x")
     ).to eq CKB::Utils.byte_to_shannon(61)
   end
 end

--- a/spec/ckb/types/script_spec.rb
+++ b/spec/ckb/types/script_spec.rb
@@ -13,13 +13,40 @@ RSpec.describe CKB::Types::Script do
 
   let(:code_hash) { "0xc00073200d2b2f4ad816a8d04bb2431ce0d3ebd49141b086eda4ab4e06bc3a21" }
 
-  it "to_hash" do
-    skip if ENV["SKIP_RPC_TESTS"]
+  context "to_hash" do
+    before do
+      skip if ENV["SKIP_RPC_TESTS"]
+    end
 
-    api = CKB::API.new
-    expect(
-      script.to_hash(api)
-    ).to eq "0xd0e22f863da970a3ff51a937ae78ba490bbdcede7272d658a053b9f80e30305d"
+    let(:api) { CKB::API.new }
+
+    it "should build correct hash when args is empty " do
+      expect(
+        script.compute_hash
+      ).to eq api.compute_script_hash(script)
+    end
+
+    it "should build correct hash when there is only one arg" do
+      CKB::Types::Script.new(
+        code_hash: code_hash,
+        args: ["0x3954acece65096bfa81258983ddb83915fc56bd8"]
+      )
+
+      expect(
+        script.compute_hash
+      ).to eq api.compute_script_hash(script)
+    end
+
+    it "should build correct hash when args more than one" do
+      CKB::Types::Script.new(
+        code_hash: code_hash,
+        args: ["0x3954acece65096bfa81258983ddb83915fc56bd8",  "0x3954acece65096bfa81258983ddb83915fc56bd83232323"]
+      )
+
+      expect(
+        script.compute_hash
+      ).to eq api.compute_script_hash(script)
+    end
   end
 
   context "calculate bytesize" do

--- a/spec/ckb/types/transaction_spec.rb
+++ b/spec/ckb/types/transaction_spec.rb
@@ -1,3 +1,4 @@
+require "pry"
 RSpec.describe CKB::Types::Transaction do
   let(:tx_to_sign_hash) do
     {
@@ -142,6 +143,210 @@ RSpec.describe CKB::Types::Transaction do
           ]
         }
       ])
+    end
+  end
+
+  context "tx_hash" do
+    it "should build correct hash for specific transaction" do
+      tx_h = {
+        :version=>"0",
+        :cell_deps=>[],
+        :header_deps=>[],
+        :inputs=>
+          [{:previous_output=>
+              {:tx_hash=>"0x0000000000000000000000000000000000000000000000000000000000000000", :index=>"4294967295"},
+            :since=>"1000"}],
+        :outputs=>
+          [{:capacity=>"125488283274",
+            :lock=>
+              {:code_hash=>"0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
+               :args=>["0x0001acc717d6424ee6efdd84e0c5befb8e44a89c"],
+               :hash_type=>"type"},
+            :type=>nil}],
+        :outputs_data=>["0x48656c6c6f2c204b652057616e67212120456e6a6f7921"],
+        :witnesses=>
+          [{:data=>
+              ["0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e8801", "0x0001acc717d6424ee6efdd84e0c5befb8e44a89c"]}],
+        :hash=>"0xa6d3c96424b16b35897b254f8d02c58dffd7ddf73aa0fe6781b0ee7a1a3e6896"
+      }
+      tx = CKB::Types::Transaction.from_h(tx_h)
+      tx_binary = CKB::Serializers::RawTransactionSerializer.new(tx).serialize
+      blake2b = CKB::Blake2b.new
+      blake2b << CKB::Utils.hex_to_bin("0x#{tx_binary}")
+      expected_tx_hash = blake2b.hexdigest
+
+      expect(
+        expected_tx_hash
+      ).to eq tx.hash
+    end
+
+    it "should build correct hash when tx has one cell_deps" do
+      tx_h = {
+        :version=>"0",
+        :cell_deps=>
+          [{:out_point=>{:tx_hash=>"0xc12386705b5cbb312b693874f3edf45c43a274482e27b8df0fd80c8d3f5feb8b", :index=>"0"},
+            :dep_type=>"dep_group"}],
+        :header_deps=>[],
+        :inputs=>
+          [{:previous_output=>
+              {:tx_hash=>"0x1a565d7d24705b65aea74e7c5cdbbdf43f00c1a0b9f7e11e4bde0f54321bb429", :index=>"1"},
+            :since=>"0"}],
+        :outputs=>
+          [{:capacity=>"100000000000",
+            :lock=>
+              {:code_hash=>"0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
+               :args=>["0xf485c551e77fc77750115a36b7d2033fbab00951"],
+               :hash_type=>"type"},
+            :type=>nil},
+           {:capacity=>"98624000000000",
+            :lock=>
+              {:code_hash=>"0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
+               :args=>["0x59a27ef3ba84f061517d13f42cf44ed020610061"],
+               :hash_type=>"type"},
+            :type=>nil}],
+        :outputs_data=>["0x", "0x"],
+        :witnesses=>
+          [{:data=>
+              ["0x7d31e525720fd16d5500aad97f92ee87a97e9510259621c77776f75f8703b90618bd07ff2d5a447553df272d1203ce090dd11f236fbd60f992a49445ff09d8fd01"]}],
+        :hash=>"0xf880ae727eaf2dec563c7ea943c24f7496ccf2fb077af408347a17701eb52ee3"
+      }
+      tx = CKB::Types::Transaction.from_h(tx_h)
+      tx_binary = CKB::Serializers::RawTransactionSerializer.new(tx).serialize
+      blake2b = CKB::Blake2b.new
+      blake2b << CKB::Utils.hex_to_bin("0x#{tx_binary}")
+      expected_tx_hash = blake2b.hexdigest
+
+      expect(
+        expected_tx_hash
+      ).to eq tx.hash
+    end
+
+    it "should build correct hash when tx has multiple cell_deps" do
+      tx_h = {
+        :version=>"0",
+        :cell_deps=>
+          [{:out_point=>{:tx_hash=>"0xc12386705b5cbb312b693874f3edf45c43a274482e27b8df0fd80c8d3f5feb8b", :index=>"0"},
+            :dep_type=>"dep_group"}],
+        :header_deps=>[],
+        :inputs=>
+          [{:previous_output=>
+              {:tx_hash=>"0x1a565d7d24705b65aea74e7c5cdbbdf43f00c1a0b9f7e11e4bde0f54321bb429", :index=>"1"},
+            :since=>"0"}],
+        :outputs=>
+          [{:capacity=>"100000000000",
+            :lock=>
+              {:code_hash=>"0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
+               :args=>["0xf485c551e77fc77750115a36b7d2033fbab00951"],
+               :hash_type=>"type"},
+            :type=>nil},
+           {:capacity=>"98624000000000",
+            :lock=>
+              {:code_hash=>"0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
+               :args=>["0x59a27ef3ba84f061517d13f42cf44ed020610061"],
+               :hash_type=>"type"},
+            :type=>nil}],
+        :outputs_data=>["0x", "0x"],
+        :witnesses=>
+          [{:data=>
+              ["0x7d31e525720fd16d5500aad97f92ee87a97e9510259621c77776f75f8703b90618bd07ff2d5a447553df272d1203ce090dd11f236fbd60f992a49445ff09d8fd01"]}],
+        :hash=>"0xf880ae727eaf2dec563c7ea943c24f7496ccf2fb077af408347a17701eb52ee3"
+      }
+      tx = CKB::Types::Transaction.from_h(tx_h)
+      tx_binary = CKB::Serializers::RawTransactionSerializer.new(tx).serialize
+      blake2b = CKB::Blake2b.new
+      blake2b << CKB::Utils.hex_to_bin("0x#{tx_binary}")
+      expected_tx_hash = blake2b.hexdigest
+
+      expect(
+        expected_tx_hash
+      ).to eq tx.hash
+    end
+
+    it "should build correct hash when has dep_type is code cell_dep" do
+      tx_h = {
+        :version=>"0",
+        :cell_deps=>
+          [{:out_point=>{:tx_hash=>"0x0fb4945d52baf91e0dee2a686cdd9d84cad95b566a1d7409b970ee0a0f364f60", :index=>"2"},
+            :dep_type=>"code"},
+           {:out_point=>{:tx_hash=>"0xc12386705b5cbb312b693874f3edf45c43a274482e27b8df0fd80c8d3f5feb8b", :index=>"0"},
+            :dep_type=>"dep_group"}],
+        :header_deps=>
+          ["0x28a548494dfc02a952f5ae25bf2886abb7ba5a8092bd139700641b4979a57217", "0x3bff5d655b9e309f0d0bfea2b792e720a88df702a5724dbb9beef92516827b3f"],
+        :inputs=>
+          [{:previous_output=>
+              {:tx_hash=>"0x9d1bf801b235ce62812844f01381a070c0cc72876364861e00492eac1d8b54e7", :index=>"0"},
+            :since=>"67744"}],
+        :outputs=>
+          [{:capacity=>"100533620439",
+            :lock=>
+              {:code_hash=>"0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
+               :args=>["0x59a27ef3ba84f061517d13f42cf44ed020610061"],
+               :hash_type=>"type"},
+            :type=>nil}],
+        :outputs_data=>["0x"],
+        :witnesses=>
+          [{:data=>
+              ["0x25d094fdab0bfbb0261f4d665a340bfcfca1cc33be317b654dd1ea2a9c42b05847cfe13ce5eae67335858295e456ebc3d40bf44f98e862974799890d6401215300",
+               "0x0000000000000000"]}],
+        :hash=>"0xf50bfe4da5a3378262769d35fd489468a89a525bc40a73d678fdb8c603c6cfb0"
+      }
+
+      tx = CKB::Types::Transaction.from_h(tx_h)
+      tx_binary = CKB::Serializers::RawTransactionSerializer.new(tx).serialize
+      blake2b = CKB::Blake2b.new
+      blake2b << CKB::Utils.hex_to_bin("0x#{tx_binary}")
+      expected_tx_hash = blake2b.hexdigest
+
+      expect(
+        expected_tx_hash
+      ).to eq tx.hash
+    end
+
+    it "should build correct hash when has type script" do
+      tx_h = {
+        :version=>"0",
+        :cell_deps=>
+          [{:out_point=>{:tx_hash=>"0xc12386705b5cbb312b693874f3edf45c43a274482e27b8df0fd80c8d3f5feb8b", :index=>"0"},
+            :dep_type=>"dep_group"},
+           {:out_point=>{:tx_hash=>"0x0fb4945d52baf91e0dee2a686cdd9d84cad95b566a1d7409b970ee0a0f364f60", :index=>"2"},
+            :dep_type=>"code"}],
+        :header_deps=>[],
+        :inputs=>
+          [{:previous_output=>
+              {:tx_hash=>"0x31f695263423a4b05045dd25ce6692bb55d7bba2965d8be16b036e138e72cc65", :index=>"1"},
+            :since=>"0"}],
+        :outputs=>
+          [{:capacity=>"100000000000",
+            :lock=>
+              {:code_hash=>"0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
+               :args=>["0x59a27ef3ba84f061517d13f42cf44ed020610061"],
+               :hash_type=>"type"},
+            :type=>
+              {:code_hash=>"0xece45e0979030e2f8909f76258631c42333b1e906fd9701ec3600a464a90b8f6",
+               :args=>[],
+               :hash_type=>"data"}},
+           {:capacity=>"98824000000000",
+            :lock=>
+              {:code_hash=>"0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e88",
+               :args=>["0x59a27ef3ba84f061517d13f42cf44ed020610061"],
+               :hash_type=>"type"},
+            :type=>nil}],
+        :outputs_data=>["0x", "0x"],
+        :witnesses=>
+          [{:data=>
+              ["0x82df73581bcd08cb9aa270128d15e79996229ce8ea9e4f985b49fbf36762c5c37936caf3ea3784ee326f60b8992924fcf496f9503c907982525a3436f01ab32900"]}],
+        :hash=>"0x9d1bf801b235ce62812844f01381a070c0cc72876364861e00492eac1d8b54e7"
+      }
+
+      tx = CKB::Types::Transaction.from_h(tx_h)
+      tx_binary = CKB::Serializers::RawTransactionSerializer.new(tx).serialize
+      blake2b = CKB::Blake2b.new
+      blake2b << CKB::Utils.hex_to_bin("0x#{tx_binary}")
+      expected_tx_hash = blake2b.hexdigest
+
+      expect(
+        expected_tx_hash
+      ).to eq tx.hash
     end
   end
 end

--- a/spec/ckb/types/transaction_spec.rb
+++ b/spec/ckb/types/transaction_spec.rb
@@ -146,9 +146,9 @@ RSpec.describe CKB::Types::Transaction do
     end
   end
 
-  context "tx_hash" do
-    it "should build correct hash for specific transaction" do
-      tx_h = {
+  context "generate tx_hash" do
+    let(:specific_tx_h) do
+      {
         :version=>"0",
         :cell_deps=>[],
         :header_deps=>[],
@@ -167,21 +167,12 @@ RSpec.describe CKB::Types::Transaction do
         :witnesses=>
           [{:data=>
               ["0x68d5438ac952d2f584abf879527946a537e82c7f3c1cbf6d8ebf9767437d8e8801", "0x0001acc717d6424ee6efdd84e0c5befb8e44a89c"]}],
-        :hash=>"0xa6d3c96424b16b35897b254f8d02c58dffd7ddf73aa0fe6781b0ee7a1a3e6896"
+        :hash=>"0xc6da9fd9f29b269b302b388f59329c16131c7f4487f5c59d01094bd5db7c9847"
       }
-      tx = CKB::Types::Transaction.from_h(tx_h)
-      tx_binary = CKB::Serializers::RawTransactionSerializer.new(tx).serialize
-      blake2b = CKB::Blake2b.new
-      blake2b << CKB::Utils.hex_to_bin("0x#{tx_binary}")
-      expected_tx_hash = blake2b.hexdigest
-
-      expect(
-        expected_tx_hash
-      ).to eq tx.hash
     end
 
-    it "should build correct hash when tx has one cell_deps" do
-      tx_h = {
+    let(:one_cell_dep_tx_h) do
+      {
         :version=>"0",
         :cell_deps=>
           [{:out_point=>{:tx_hash=>"0xc12386705b5cbb312b693874f3edf45c43a274482e27b8df0fd80c8d3f5feb8b", :index=>"0"},
@@ -208,21 +199,12 @@ RSpec.describe CKB::Types::Transaction do
         :witnesses=>
           [{:data=>
               ["0x7d31e525720fd16d5500aad97f92ee87a97e9510259621c77776f75f8703b90618bd07ff2d5a447553df272d1203ce090dd11f236fbd60f992a49445ff09d8fd01"]}],
-        :hash=>"0xf880ae727eaf2dec563c7ea943c24f7496ccf2fb077af408347a17701eb52ee3"
+        :hash=>"0x5cf2f68d5d22a0f58465564490a4fe4e88af2d1d3592c4033cb27a2450c6c27e"
       }
-      tx = CKB::Types::Transaction.from_h(tx_h)
-      tx_binary = CKB::Serializers::RawTransactionSerializer.new(tx).serialize
-      blake2b = CKB::Blake2b.new
-      blake2b << CKB::Utils.hex_to_bin("0x#{tx_binary}")
-      expected_tx_hash = blake2b.hexdigest
-
-      expect(
-        expected_tx_hash
-      ).to eq tx.hash
     end
 
-    it "should build correct hash when tx has multiple cell_deps" do
-      tx_h = {
+    let(:multiple_cell_dep_tx_h) do
+      {
         :version=>"0",
         :cell_deps=>
           [{:out_point=>{:tx_hash=>"0xc12386705b5cbb312b693874f3edf45c43a274482e27b8df0fd80c8d3f5feb8b", :index=>"0"},
@@ -249,21 +231,12 @@ RSpec.describe CKB::Types::Transaction do
         :witnesses=>
           [{:data=>
               ["0x7d31e525720fd16d5500aad97f92ee87a97e9510259621c77776f75f8703b90618bd07ff2d5a447553df272d1203ce090dd11f236fbd60f992a49445ff09d8fd01"]}],
-        :hash=>"0xf880ae727eaf2dec563c7ea943c24f7496ccf2fb077af408347a17701eb52ee3"
+        :hash=>"0x5cf2f68d5d22a0f58465564490a4fe4e88af2d1d3592c4033cb27a2450c6c27e"
       }
-      tx = CKB::Types::Transaction.from_h(tx_h)
-      tx_binary = CKB::Serializers::RawTransactionSerializer.new(tx).serialize
-      blake2b = CKB::Blake2b.new
-      blake2b << CKB::Utils.hex_to_bin("0x#{tx_binary}")
-      expected_tx_hash = blake2b.hexdigest
-
-      expect(
-        expected_tx_hash
-      ).to eq tx.hash
     end
 
-    it "should build correct hash when has dep_type is code cell_dep" do
-      tx_h = {
+    let(:code_dep_type_tx_h) do
+      {
         :version=>"0",
         :cell_deps=>
           [{:out_point=>{:tx_hash=>"0x0fb4945d52baf91e0dee2a686cdd9d84cad95b566a1d7409b970ee0a0f364f60", :index=>"2"},
@@ -288,22 +261,12 @@ RSpec.describe CKB::Types::Transaction do
           [{:data=>
               ["0x25d094fdab0bfbb0261f4d665a340bfcfca1cc33be317b654dd1ea2a9c42b05847cfe13ce5eae67335858295e456ebc3d40bf44f98e862974799890d6401215300",
                "0x0000000000000000"]}],
-        :hash=>"0xf50bfe4da5a3378262769d35fd489468a89a525bc40a73d678fdb8c603c6cfb0"
+        :hash=>"0x3d1624dada9eafe506f8d0a44531993a41a91b496e5ce3ea18e16322ec997944"
       }
-
-      tx = CKB::Types::Transaction.from_h(tx_h)
-      tx_binary = CKB::Serializers::RawTransactionSerializer.new(tx).serialize
-      blake2b = CKB::Blake2b.new
-      blake2b << CKB::Utils.hex_to_bin("0x#{tx_binary}")
-      expected_tx_hash = blake2b.hexdigest
-
-      expect(
-        expected_tx_hash
-      ).to eq tx.hash
     end
 
-    it "should build correct hash when has type script" do
-      tx_h = {
+    let(:has_type_script_tx_h) do
+      {
         :version=>"0",
         :cell_deps=>
           [{:out_point=>{:tx_hash=>"0xc12386705b5cbb312b693874f3edf45c43a274482e27b8df0fd80c8d3f5feb8b", :index=>"0"},
@@ -335,18 +298,96 @@ RSpec.describe CKB::Types::Transaction do
         :witnesses=>
           [{:data=>
               ["0x82df73581bcd08cb9aa270128d15e79996229ce8ea9e4f985b49fbf36762c5c37936caf3ea3784ee326f60b8992924fcf496f9503c907982525a3436f01ab32900"]}],
-        :hash=>"0x9d1bf801b235ce62812844f01381a070c0cc72876364861e00492eac1d8b54e7"
+        :hash=>"0x09ce2223304a5f48d5ce2b6ee2777d96503591279671460fa39ae894ea9e2b87"
       }
+    end
 
-      tx = CKB::Types::Transaction.from_h(tx_h)
-      tx_binary = CKB::Serializers::RawTransactionSerializer.new(tx).serialize
-      blake2b = CKB::Blake2b.new
-      blake2b << CKB::Utils.hex_to_bin("0x#{tx_binary}")
-      expected_tx_hash = blake2b.hexdigest
+    it "should build correct hash for specific transaction" do
+      tx = CKB::Types::Transaction.from_h(specific_tx_h)
 
       expect(
-        expected_tx_hash
+        tx.compute_hash
       ).to eq tx.hash
+    end
+
+    it "should build correct hash when tx has one cell_deps" do
+      tx = CKB::Types::Transaction.from_h(one_cell_dep_tx_h)
+
+      expect(
+        tx.compute_hash
+      ).to eq tx.hash
+    end
+
+    it "should build correct hash when tx has multiple cell_deps" do
+      tx = CKB::Types::Transaction.from_h(multiple_cell_dep_tx_h)
+
+      expect(
+        tx.compute_hash
+      ).to eq tx.hash
+    end
+
+    it "should build correct hash when has dep_type is code cell_dep" do
+      tx = CKB::Types::Transaction.from_h(code_dep_type_tx_h)
+
+      expect(
+        tx.compute_hash
+      ).to eq tx.hash
+    end
+
+    it "should build correct hash when has type script" do
+      tx = CKB::Types::Transaction.from_h(has_type_script_tx_h)
+
+      expect(
+        tx.compute_hash
+      ).to eq tx.hash
+    end
+
+    context "compared with rpc result" do
+      before do
+        skip "not call rpc" if ENV["SKIP_RPC_TESTS"]
+      end
+
+      let(:api) { CKB::API.new }
+
+      it "should build correct hash for specific transaction" do
+        tx = CKB::Types::Transaction.from_h(specific_tx_h)
+
+        expect(
+          tx.compute_hash
+        ).to eq api.compute_transaction_hash(tx)
+      end
+
+      it "should build correct hash when tx has one cell_deps" do
+        tx = CKB::Types::Transaction.from_h(one_cell_dep_tx_h)
+
+        expect(
+          tx.compute_hash
+        ).to eq api.compute_transaction_hash(tx)
+      end
+
+      it "should build correct hash when tx has multiple cell_deps" do
+        tx = CKB::Types::Transaction.from_h(multiple_cell_dep_tx_h)
+
+        expect(
+          tx.compute_hash
+        ).to eq api.compute_transaction_hash(tx)
+      end
+
+      it "should build correct hash when has dep_type is code cell_dep" do
+        tx = CKB::Types::Transaction.from_h(code_dep_type_tx_h)
+
+        expect(
+          tx.compute_hash
+        ).to eq api.compute_transaction_hash(tx)
+      end
+
+      it "should build correct hash when has type script" do
+        tx = CKB::Types::Transaction.from_h(has_type_script_tx_h)
+
+        expect(
+          tx.compute_hash
+        ).to eq api.compute_transaction_hash(tx)
+      end
     end
   end
 end


### PR DESCRIPTION
# [v0.20.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.19.0...v0.20.0) (2019-09-07)


### Bug Fixes

* test ([8ac5926](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/8ac5926))
* type script serialization ([b72fe3e](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/b72fe3e))
* wrong dep_type value ([51d5f95](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/51d5f95))


### Features

* add composite data serializers ([7783444](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/7783444))
* add compute_hash to transaction ([7ae9c92](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/7ae9c92))
* add compute_transaction_hash method ([d69ebf2](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/d69ebf2))
* add transaction serialization related serializers ([4488008](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/4488008))
* serialize script ([155c472](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/155c472))
* update expected code_hash and type_hash ([37f0684](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/37f0684))
* update expected code_hash and type_hash ([313ee86](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/313ee86))
* use struct replace some table ([c5e1f17](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/c5e1f17))