### PR TITLE
feat: Add MockTransactionDumper

### DIFF
--- a/lib/ckb.rb
+++ b/lib/ckb.rb
@@ -14,6 +14,7 @@ require "ckb/wallet"
 require "ckb/address"
 require "ckb/key"
 require "ckb/serializers/serializers"
+require "ckb/mock_transaction_dumper"
 
 module CKB
   class Error < StandardError; end

--- a/lib/ckb/api.rb
+++ b/lib/ckb/api.rb
@@ -10,6 +10,8 @@ module CKB
   class API
     attr_reader :rpc
     attr_reader :secp_group_out_point
+    attr_reader :secp_code_out_point
+    attr_reader :secp_data_out_point
     attr_reader :secp_cell_type_hash
     attr_reader :secp_cell_code_hash
     attr_reader :dao_out_point
@@ -31,6 +33,15 @@ module CKB
         raise "System script code_hash error!" unless code_hash == expected_code_hash
 
         @secp_cell_code_hash = code_hash
+
+        @secp_code_out_point = Types::OutPoint.new(
+          tx_hash: system_cell_transaction.hash,
+          index: 1
+        )
+        @secp_data_out_point = Types::OutPoint.new(
+          tx_hash: system_cell_transaction.hash,
+          index: 3
+        )
 
         secp_group_cell_transaction = genesis_block.transactions[1]
         secp_group_out_point = Types::OutPoint.new(

--- a/lib/ckb/mock_transaction_dumper.rb
+++ b/lib/ckb/mock_transaction_dumper.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module CKB
+  class MockTransactionDumper
+    attr_reader :api, :transaction
+
+    def initialize(api, transaction)
+      @api = api
+      @transaction = transaction
+    end
+
+    def dump
+      mock_inputs = transaction.inputs.map do |input|
+        cell_with_status = api.get_live_cell(input.previous_output, true)
+        unless cell_with_status && cell_with_status.cell
+          raise "Cannot find input cell: #{input.previous_output}"
+        end
+        {
+          input: input.to_h,
+          output: cell_with_status.cell.output.to_h,
+          data: cell_with_status.cell.data.content
+        }
+      end
+      mock_cell_deps = transaction.cell_deps.map do |cell_dep|
+        # TODO: add group cell dep support once we have molecule parser in
+        # Ruby to parse group cell dep contents.
+        raise "Group cell dep is not supported yet" unless cell_dep.dep_type == "code"
+        cell_with_status = api.get_live_cell(cell_dep.out_point, true)
+        unless cell_with_status && cell_with_status.cell
+          raise "Cannot find cell dep: #{cell_dep.out_point}"
+        end
+        {
+          cell_dep: cell_dep.to_h,
+          output: cell_with_status.cell.output.to_h,
+          data: cell_with_status.cell.data.content
+        }
+      end
+      mock_headers = transaction.header_deps.map do |header_dep|
+        header = api.get_header(header_dep)
+        raise "Cannot find header: #{header_dep}" unless header
+        header.to_h
+      end
+      {
+        mock_info: {
+          inputs: mock_inputs,
+          cell_deps: mock_cell_deps,
+          header_deps: mock_headers
+        },
+        tx: transaction.to_raw_transaction_h
+      }
+    end
+
+    def write(file)
+      File.write(file, JSON.pretty_generate(dump))
+    end
+  end
+end

--- a/lib/ckb/wallet.rb
+++ b/lib/ckb/wallet.rb
@@ -70,7 +70,7 @@ module CKB
     # @param data [String ] "0x..."
     # @param key [CKB::Key | String] Key or private key hex string
     # @param fee [Integer] transaction fee, in shannon
-    def generate_tx(target_address, capacity, data = "0x", key: nil, fee: 0)
+    def generate_tx(target_address, capacity, data = "0x", key: nil, fee: 0, use_dep_group: true)
       key = get_key(key)
 
       output = Types::Output.new(
@@ -107,14 +107,19 @@ module CKB
 
       tx = Types::Transaction.new(
         version: 0,
-        cell_deps: [
-          Types::CellDep.new(out_point: api.secp_group_out_point, dep_type: "dep_group")
-        ],
+        cell_deps: [],
         inputs: i.inputs,
         outputs: outputs,
         outputs_data: outputs_data,
         witnesses: i.witnesses
       )
+
+      if use_dep_group
+        tx.cell_deps << Types::CellDep.new(out_point: api.secp_group_out_point, dep_type: "dep_group")
+      else
+        tx.cell_deps << Types::CellDep.new(out_point: api.secp_code_out_point, dep_type: "code")
+        tx.cell_deps << Types::CellDep.new(out_point: api.secp_data_out_point, dep_type: "code")
+      end
 
       tx.sign(key, tx.compute_hash)
     end


### PR DESCRIPTION
MockTransactionDumper can generate transaction data with additional information, such as input/dep data, so the dumped data can be directly used in an offchain CKB debugger, or in CKB CLI.