### PR TITLE
docs: Guide the user to install libsecp256k1 manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Require Ruby 2.4 and above.
 ### Ubuntu
 
 ```bash
-sudo apt install libsecp256k1-dev libsodium-dev
+sudo apt install libsodium-dev
 ```
 
-This SDK depends on the [bitcoin-secp256k1](https://github.com/cryptape/ruby-bitcoin-secp256k1) gem. If you are using Ubuntu 16.04 or below, you might need to install libsecp256k1 with `--enable-module-recovery` (on which bitcoin-secp256k1 depends) manually. Follow [this](https://github.com/cryptape/ruby-bitcoin-secp256k1#prerequisite) to do so.
+This SDK depends on the [bitcoin-secp256k1](https://github.com/cryptape/ruby-bitcoin-secp256k1) gem. You need to install libsecp256k1 with `--enable-module-recovery` (on which bitcoin-secp256k1 depends) manually. Follow [this](https://github.com/cryptape/ruby-bitcoin-secp256k1#prerequisite) to do so.
 
 ### macOS
 


### PR DESCRIPTION
since libsecp256k1-dev doesn't have recovery module enabled