### PR TITLE
[ᚬmaster] Rc/v0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [v0.25.1](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.25.0...v0.25.1) (2019-11-17)
+
+
+### Bug Fixes
+
+* add default value for reduce in get_unspent_cells ([e14901b](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/e14901bbbde21c17d75546669ab3081e2850af70))
+
+
 # [v0.25.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.24.0...v0.25.0) (2019-11-16)
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ckb-sdk-ruby (0.25.0)
+    ckb-sdk-ruby (0.25.1)
       bitcoin-secp256k1 (~> 0.5.2)
       net-http-persistent (~> 3.0.0)
       rbnacl (~> 6.0, >= 6.0.1)

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Require Ruby 2.4 and above.
 ### Ubuntu
 
 ```bash
-sudo apt install libsecp256k1-dev libsodium-dev
+sudo apt install libsodium-dev
 ```
 
-This SDK depends on the [bitcoin-secp256k1](https://github.com/cryptape/ruby-bitcoin-secp256k1) gem. If you are using Ubuntu 16.04 or below, you might need to install libsecp256k1 with `--enable-module-recovery` (on which bitcoin-secp256k1 depends) manually. Follow [this](https://github.com/cryptape/ruby-bitcoin-secp256k1#prerequisite) to do so.
+This SDK depends on the [bitcoin-secp256k1](https://github.com/cryptape/ruby-bitcoin-secp256k1) gem. You need to install libsecp256k1 with `--enable-module-recovery` (on which bitcoin-secp256k1 depends) manually. Follow [this](https://github.com/cryptape/ruby-bitcoin-secp256k1#prerequisite) to do so.
 
 ### macOS
 

--- a/lib/ckb/cell_collector.rb
+++ b/lib/ckb/cell_collector.rb
@@ -37,7 +37,7 @@ module CKB
           break if need_capacities && total_capacities >= need_capacities
         else
           results.concat(cells)
-          total_capacities += cells.map(&:capacity).reduce(:+)
+          total_capacities += cells.map(&:capacity).reduce(0, :+)
           break if need_capacities && total_capacities >= need_capacities
         end
         current_from = current_to + 1

--- a/lib/ckb/version.rb
+++ b/lib/ckb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CKB
-  VERSION = "0.25.0"
+  VERSION = "0.25.1"
 end


### PR DESCRIPTION
# [v0.25.1](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.25.0...v0.25.1) (2019-11-17)


### Bug Fixes

* add default value for reduce in get_unspent_cells ([e14901b](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/e14901bbbde21c17d75546669ab3081e2850af70))