### PR TITLE
[ᚬmaster] Rc/v0.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [v0.25.2](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.25.1...v0.25.2) (2019-11-17)
+
+
+### Bug Fixes
+
+* add options to wallet.from_hex ([ac2b658](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/ac2b658cada45dcbec0b041ea2347e0b072f43d1))
+
+
 # [v0.25.1](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.25.0...v0.25.1) (2019-11-17)
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ckb-sdk-ruby (0.25.1)
+    ckb-sdk-ruby (0.25.2)
       bitcoin-secp256k1 (~> 0.5.2)
       net-http-persistent (~> 3.0.0)
       rbnacl (~> 6.0, >= 6.0.1)

--- a/lib/ckb/version.rb
+++ b/lib/ckb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CKB
-  VERSION = "0.25.1"
+  VERSION = "0.25.2"
 end


### PR DESCRIPTION
# [v0.25.2](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.25.1...v0.25.2) (2019-11-17)


### Bug Fixes

* add options to wallet.from_hex ([ac2b658](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/ac2b658cada45dcbec0b041ea2347e0b072f43d1))