### PR TITLE
[ᚬmaster] Rc/v0.26.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - 2.5.3
   - 2.6.1
 env:
-  - SKIP_RPC_TESTS=true
+  - SKIP_RPC_TESTS=true BOB_PRIVATE_KEY="0xe79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3"
 before_install:
   - gem install bundler -v 2.0.1
   - sudo apt-get update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [v0.26.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.25.2...v0.26.0) (2019-12-16)
+
+
+### Features
+
+* update `get_cells_by_lock_hash` and `get_live_cells_by_lock` returns ([65f76c4](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/65f76c48ce91752442aa68dc57af0a9a7061ac9e))
+
+
 # [v0.25.2](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.25.1...v0.25.2) (2019-11-17)
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ckb-sdk-ruby (0.25.2)
+    ckb-sdk-ruby (0.26.0)
       bitcoin-secp256k1 (~> 0.5.2)
       net-http-persistent (~> 3.0.0)
       rbnacl (~> 6.0, >= 6.0.1)

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ bob_key = "0xe79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3"
 tx_hash = bob.send_capacity(alice.address, 1000 * 10**8, key: bob_key)
 ```
 
+## Run Tests
+
+```bash
+BOB_PRIVATE_KEY="0xe79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3" rake spec
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/ckb/types/cell_output_with_out_point.rb
+++ b/lib/ckb/types/cell_output_with_out_point.rb
@@ -3,22 +3,33 @@
 module CKB
   module Types
     class CellOutputWithOutPoint
-      attr_accessor :lock, :out_point, :block_hash
-      attr_reader :capacity
+      attr_accessor :lock, :out_point, :block_hash, :cellbase, :type
+      attr_reader :capacity, :output_data_len
 
       # @param capacity [String | Integer] integer or hex number
       # @param lock [CKB::Types::Script]
       # @param out_point [CKB::Types::OutPoint]
       # @param block_hash [String]
-      def initialize(capacity:, lock:, out_point:, block_hash:)
-        @capacity = Utils.to_int(capacity)
+      # @param cellbase: [Boolean]
+      # @param output_data_len [Integer]
+      # @param type [CKB::Types::Script | nil]
+      def initialize(capacity:, lock:, out_point:, block_hash:, cellbase:, output_data_len:, type: nil)
         @lock = lock
         @out_point = out_point
         @block_hash = block_hash
+        @cellbase = cellbase
+        @type = type
+
+        self.capacity = capacity
+        self.output_data_len = output_data_len
       end
 
       def capacity=(value)
         @capacity = Utils.to_int(value)
+      end
+
+      def output_data_len=(value)
+        @output_data_len = Utils.to_int(value)
       end
 
       def to_h
@@ -26,7 +37,10 @@ module CKB
           capacity: Utils.to_hex(@capacity),
           lock: @lock.to_h,
           block_hash: @block_hash,
-          out_point: @out_point.to_h
+          out_point: @out_point.to_h,
+          cellbase: @cellbase,
+          type: @type ? @type.to_h : nil,
+          output_data_len: Utils.to_hex(@output_data_len)
         }
       end
 
@@ -37,7 +51,10 @@ module CKB
           capacity: hash[:capacity],
           lock: Script.from_h(hash[:lock]),
           out_point: OutPoint.from_h(hash[:out_point]),
-          block_hash: hash[:block_hash]
+          block_hash: hash[:block_hash],
+          output_data_len: hash[:output_data_len],
+          cellbase: hash[:cellbase],
+          type: Script.from_h(hash[:type]),
         )
       end
     end

--- a/lib/ckb/types/live_cell.rb
+++ b/lib/ckb/types/live_cell.rb
@@ -3,19 +3,31 @@
 module CKB
   module Types
     class LiveCell
-      attr_accessor :cell_output, :created_by
+      attr_accessor :cell_output, :created_by, :cellbase
+      attr_reader :output_data_len
 
       # @param cell_output [Types::Output]
       # @param created_by [Types::TransactionPoint]
-      def initialize(cell_output:, created_by:)
+      # @param cellbase [Boolean]
+      # @param output_data_len [Integer]
+      def initialize(cell_output:, created_by:, cellbase:, output_data_len:)
         @cell_output = cell_output
         @created_by = created_by
+        @cellbase = cellbase
+
+        self.output_data_len = output_data_len
+      end
+
+      def output_data_len=(value)
+        @output_data_len = Utils.to_int(value)
       end
 
       def to_h
         {
           cell_output: @cell_output.to_h,
-          created_by: @created_by.to_h
+          created_by: @created_by.to_h,
+          cellbase: @cellbase,
+          output_data_len: Utils.to_hex(@output_data_len)
         }
       end
 
@@ -24,7 +36,9 @@ module CKB
 
         new(
           cell_output: Output.from_h(hash[:cell_output]),
-          created_by: TransactionPoint.from_h(hash[:created_by])
+          created_by: TransactionPoint.from_h(hash[:created_by]),
+          cellbase: hash[:cellbase],
+          output_data_len: hash[:output_data_len]
         )
       end
     end

--- a/lib/ckb/version.rb
+++ b/lib/ckb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CKB
-  VERSION = "0.25.2"
+  VERSION = "0.26.0"
 end

--- a/spec/ckb/key_spec.rb
+++ b/spec/ckb/key_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe CKB::Key do
-  let(:privkey) { "0xe79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3" }
+  let(:privkey) { ENV["BOB_PRIVATE_KEY"] }
   let(:pubkey) { "0x024a501efd328e062c8675f2365970728c859c592beeefd6be8ead3d901330bc01" }
   let(:privkey_bin) { Utils.hex_to_bin(privkey) }
   let(:pubkey_bin) { Utils.hex_to_bin(pubkey) }

--- a/spec/ckb/types/cell_output_with_out_point_spec.rb
+++ b/spec/ckb/types/cell_output_with_out_point_spec.rb
@@ -11,6 +11,13 @@ RSpec.describe CKB::Types::CellOutputWithOutPoint do
       "out_point": {
           "index": "0x0",
           "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
+      },
+      "cellbase": true,
+      "output_data_len": "0x0",
+      "type": {
+        "args": [],
+        "code_hash": "0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5",
+        "hash_type": "data"
       }
     }
   end
@@ -20,9 +27,12 @@ RSpec.describe CKB::Types::CellOutputWithOutPoint do
   it "from_h" do
     expect(cell_output_with_out_point).to be_a(CKB::Types::CellOutputWithOutPoint)
     expect(cell_output_with_out_point.lock).to be_a(CKB::Types::Script)
+    expect(cell_output_with_out_point.type).to be_a(CKB::Types::Script)
     expect(cell_output_with_out_point.out_point).to be_a(CKB::Types::OutPoint)
     expect(cell_output_with_out_point.capacity).to eq cell_output_with_out_point_h[:capacity].hex
+    expect(cell_output_with_out_point.output_data_len).to eq cell_output_with_out_point_h[:output_data_len].hex
     expect(cell_output_with_out_point.block_hash).to eq cell_output_with_out_point_h[:block_hash]
+    expect(cell_output_with_out_point.cellbase).to eq cell_output_with_out_point_h[:cellbase]
   end
 
   it "to_h" do

--- a/spec/ckb/types/live_cell_spec.rb
+++ b/spec/ckb/types/live_cell_spec.rb
@@ -11,10 +11,12 @@ RSpec.describe CKB::Types::LiveCell do
         "type": nil
     },
     "created_by": {
-        "block_number": "0x1",
-        "index": "0x0",
-        "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
-      }
+      "block_number": "0x1",
+      "index": "0x0",
+      "tx_hash": "0x5ba156200c6310bf140fbbd3bfe7e8f03d4d5f82b612c1a8ec2501826eaabc17"
+    },
+    "cellbase": false,
+    "output_data_len": "0x0"
     }
   end
 
@@ -24,6 +26,8 @@ RSpec.describe CKB::Types::LiveCell do
     expect(live_cell).to be_a(CKB::Types::LiveCell)
     expect(live_cell.cell_output).to be_a(CKB::Types::Output)
     expect(live_cell.created_by).to be_a(CKB::Types::TransactionPoint)
+    expect(live_cell.cellbase).to eq live_cell_h[:cellbase]
+    expect(live_cell.output_data_len).to eq live_cell_h[:output_data_len].hex
   end
 
   it "to_h" do

--- a/spec/ckb/types/transaction_spec.rb
+++ b/spec/ckb/types/transaction_spec.rb
@@ -1,24 +1,57 @@
 # frozen_string_literal: true
 RSpec.describe CKB::Types::Transaction do
+  let(:private_key) { ENV["BOB_PRIVATE_KEY"] }
+  let(:key) { CKB::Key.new(private_key) }
+
   let(:tx_to_sign_hash) do
-    { version: "0x0",
-      cell_deps: [{ out_point: { tx_hash: "0xe7d5ddd093bcc5909a6f441882e58906062eaf66a6ac1bcf7d7411931bc9ab72", index: "0x0" },
-                    dep_type: "dep_group" }],
-      header_deps: [],
-      inputs: [{ previous_output: { tx_hash: "0x650b8f3fcb2627b5500c308a9b0485b806e256886c36d641517eec53707bbcf9", index: "0x0" },
-                 since: "0x0" }],
-      outputs: [{ capacity: "0x174876e800",
-                  lock: { code_hash: "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
-                          args: "0x59a27ef3ba84f061517d13f42cf44ed020610061",
-                          hash_type: "type" },
-                  type: nil },
-                { capacity: "0x182ca202c9",
-                  lock: { code_hash: "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
-                          args: "0x3954acece65096bfa81258983ddb83915fc56bd8",
-                          hash_type: "type" },
-                  type: nil }],
-      outputs_data: %w[0x 0x],
-      witnesses: [CKB::Types::Witness.new] }
+    {
+      "version": "0x0",
+      "cell_deps": [
+        {
+          "out_point": {
+            "tx_hash": "0xace5ea83c478bb866edf122ff862085789158f5cbff155b7bb5f13058555b708",
+            "index": "0x0"
+          },
+          "dep_type": "dep_group"
+        }
+      ],
+      "header_deps": [],
+      "inputs": [
+        {
+          "previous_output": {
+            "tx_hash": "0x3ac0a667dc308a78f38c75cbeedfdea9247bbd67e727e1c153a4aa1a2afb28d8",
+            "index": "0x0"
+          },
+          "since": "0x0"
+        }
+      ],
+      "outputs": [
+        {
+          "capacity": "0x174876e800",
+          "lock": {
+            "code_hash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+            "args": "0xe2193df51d78411601796b35b17b4f8f2cd85bd0",
+            "hash_type": "type"
+          },
+          "type": nil
+        },
+        {
+          "capacity": "0x123057115561",
+          "lock": {
+            "code_hash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+            "args": "0x36c329ed630d6ce750712a477543672adab57f4c",
+            "hash_type": "type"
+          },
+          "type": nil
+        }
+      ],
+      "outputs_data": [
+        "0x",
+        "0x"
+      ],
+      "witnesses": [CKB::Types::Witness.new],
+      "hash": "0x8457b932a9a3cd0bedd3eebad473cf7fd1f59cd5f96f80a637271a6901e4a0da"
+    }
   end
 
   let(:tx_to_sign_hash_use_data_hash) do
@@ -44,17 +77,15 @@ RSpec.describe CKB::Types::Transaction do
 
   it "sign" do
     tx_to_sign = CKB::Types::Transaction.from_h(tx_to_sign_hash)
-    key = CKB::Key.new("0x845b781a1a094057b972714a2b09b85de4fc2eb205351c3e5179aabd264f3805")
-    tx_hash = "0x993e6e629be2f016bf72becaa9ad4b39f7fdd72357c9341335783f451010b94e"
+    tx_hash = "0x8457b932a9a3cd0bedd3eebad473cf7fd1f59cd5f96f80a637271a6901e4a0da"
     signed_tx = tx_to_sign.sign(key)
 
     expect(signed_tx.to_h[:hash]).to eq(tx_hash)
-    expect(signed_tx.to_h[:witnesses]).to eq(["0x5500000010000000550000005500000041000000c664d7ccd7fd42810bbdaeaeb760f8d6450689665d2cade9476e50e1cf7b20186bc14aa874a8d166e2435ada65a05d870d006cdb51ed759ad00272b287f2d26c00"])
+    expect(signed_tx.to_h[:witnesses]).to eq(["0x55000000100000005500000055000000410000007c1fae2bc44369f8bca4d7532f7c7adaf978f4dbde86d3c97bca39e05c4354b17bef1b2184a99fe405e7b1ed8c70d9c314d9a6d7d46008c8b08a1a3dbb09190d01"])
   end
 
   it "sign with data hash" do
     tx_to_sign = CKB::Types::Transaction.from_h(tx_to_sign_hash_use_data_hash)
-    key = CKB::Key.new("0xe79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3")
     tx_hash = tx_to_sign.compute_hash
     signed_tx = tx_to_sign.sign(key)
 
@@ -64,44 +95,102 @@ RSpec.describe CKB::Types::Transaction do
 
   context "multiple inputs sign" do
     let(:tx_to_sign_hash) do
-      { version: "0x0",
-        cell_deps: [{ out_point: { tx_hash: "0xe7d5ddd093bcc5909a6f441882e58906062eaf66a6ac1bcf7d7411931bc9ab72", index: "0x0" },
-                      dep_type: "dep_group" }],
-        header_deps: [],
-        inputs: [{ previous_output: { tx_hash: "0xa31b9b8d105c62d69b7fbfc09bd700f3a1d6659232ffcfaa12a048ee5d7b7f2d", index: "0x0" },
-                   since: "0x0" },
-                 { previous_output: { tx_hash: "0xec5e63e19ec0161092ba78a841e9ead5deb30e56c2d98752ed974f2f2b4aeff2", index: "0x0" },
-                   since: "0x0" },
-                 { previous_output: { tx_hash: "0x5ad2600cb884572f9d8f568822c0447f6f49eb63b53257c20d0d8559276bf4e2", index: "0x0" },
-                   since: "0x0" },
-                 { previous_output: { tx_hash: "0xf21e34224e90c1ab47f42e2977ea455445d22ba3aaeb4bd2fcb2075704f330ff", index: "0x0" },
-                   since: "0x0" },
-                 { previous_output: { tx_hash: "0xc8212696d516c63bced000d3008c4a8c27c72c03f4becb40f0bf24a31063271f", index: "0x0" },
-                   since: "0x0" }],
-        outputs: [{ capacity: "0xe8d4a51000",
-                    lock: { code_hash: "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
-                            args: "0x59a27ef3ba84f061517d13f42cf44ed020610061",
-                            hash_type: "type" },
-                    type: nil },
-                  { capacity: "0x47345dea3",
-                    lock: { code_hash: "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
-                            args: "0x3954acece65096bfa81258983ddb83915fc56bd8",
-                            hash_type: "type" },
-                    type: nil }],
-        outputs_data: %w[0x 0x],
-        witnesses: [CKB::Types::Witness.new, "0x", "0x", "0x", "0x"] }
+      {
+        "version": "0x0",
+        "cell_deps": [
+          {
+            "out_point": {
+              "tx_hash": "0xace5ea83c478bb866edf122ff862085789158f5cbff155b7bb5f13058555b708",
+              "index": "0x0"
+            },
+            "dep_type": "dep_group"
+          }
+        ],
+        "header_deps": [],
+        "inputs": [
+          {
+            "previous_output": {
+              "tx_hash": "0x7f6e63319c3148eaea767cdf800d76bba4824d3a85c88e39221901c94b8255f5",
+              "index": "0x0"
+            },
+            "since": "0x0"
+          },
+          {
+            "previous_output": {
+              "tx_hash": "0xd7c23e7ffbbb70b5bf6e5d15c9c39bb7e11a16e272df4509191112d19a358415",
+              "index": "0x0"
+            },
+            "since": "0x0"
+          },
+          {
+            "previous_output": {
+              "tx_hash": "0xa674ff0b7daa0d6708f518f74122f68af0e1a67cbd5736e8b6c23c7ed289e01d",
+              "index": "0x0"
+            },
+            "since": "0x0"
+          },
+          {
+            "previous_output": {
+              "tx_hash": "0x33045ca3a14071ef73ff70d0b989f6463913d74a825b31a28a9cbdd895edcc1f",
+              "index": "0x0"
+            },
+            "since": "0x0"
+          },
+          {
+            "previous_output": {
+              "tx_hash": "0x6b59838ddfe9551299a83061935ba9dbee9920c26ab526319bbe26a67fc85cc4",
+              "index": "0x0"
+            },
+            "since": "0x0"
+          }
+        ],
+        "outputs": [
+          {
+            "capacity": "0x5af3107a4000",
+            "lock": {
+              "code_hash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "args": "0xe2193df51d78411601796b35b17b4f8f2cd85bd0",
+              "hash_type": "type"
+            },
+            "type": nil
+          },
+          {
+            "capacity": "0x7306fb4b6f",
+            "lock": {
+              "code_hash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "args": "0x36c329ed630d6ce750712a477543672adab57f4c",
+              "hash_type": "type"
+            },
+            "type": nil
+          }
+        ],
+        "outputs_data": [
+          "0x",
+          "0x"
+        ],
+        "witnesses": [
+          CKB::Types::Witness.new,
+          CKB::Types::Witness.new,
+          CKB::Types::Witness.new,
+          CKB::Types::Witness.new,
+          CKB::Types::Witness.new
+        ]
+      }
     end
 
-    let(:tx_hash) { "0x03aea57404a99c685b098b7ee96469f0c5db57fa49aaef27cf7c080960da4b19" }
-
-    let(:private_key) { "0x845b781a1a094057b972714a2b09b85de4fc2eb205351c3e5179aabd264f3805" }
-    let(:key) { CKB::Key.new(private_key) }
+    let(:tx_hash) { "0x11a67b2de5629a39a1514b39c27500bad8a52cb8ff604ddb50f0f8fc044a5448" }
 
     it "sign" do
       tx_to_sign = CKB::Types::Transaction.from_h(tx_to_sign_hash)
       signed_tx = tx_to_sign.sign(key)
       expect(signed_tx.hash).to eq tx_hash
-      expect(signed_tx.to_raw_transaction_h[:witnesses]).to eq(%w(0x550000001000000055000000550000004100000090cdaca0b898586ef68c02e8514087e620d3b19767137baf2fbc8dee28c83ac047be76c76d7f5098a759f3d417c1daedf534a3772aa29159d807d948ed1f8c3a00 0x 0x 0x 0x))
+      expect(signed_tx.to_raw_transaction_h[:witnesses]).to eq([
+        "0x550000001000000055000000550000004100000042ab4a61dec16c0dce4bdec692eb4f9814af4f50ce929cf0b88c4282e2970ce14ee827c7707676f50da13108e8ef23aed9043d7b64f78e216f2bd750888ecbae01",
+        "0x10000000100000001000000010000000",
+        "0x10000000100000001000000010000000",
+        "0x10000000100000001000000010000000",
+        "0x10000000100000001000000010000000"
+      ])
     end
 
     let(:tx_to_sign_hash_use_data_hash) do
@@ -125,7 +214,6 @@ RSpec.describe CKB::Types::Transaction do
 
     it "sign2" do
       tx_to_sign = CKB::Types::Transaction.from_h(tx_to_sign_hash_use_data_hash)
-      key = CKB::Key.new("0xe79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3")
       tx_hash = tx_to_sign.compute_hash
       signed_tx = tx_to_sign.sign(key)
 

--- a/spec/ckb/utils_spec.rb
+++ b/spec/ckb/utils_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe CKB::Utils do
   Utils = CKB::Utils
 
-  let(:privkey) { "0xe79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3" }
+  let(:privkey) { ENV["BOB_PRIVATE_KEY"] }
   let(:pubkey) { "0x024a501efd328e062c8675f2365970728c859c592beeefd6be8ead3d901330bc01" }
   let(:address) { "0xbc374983430db3686ab181138bb510cb8f83aa136d833ac18fc3e73a3ad54b8b" }
   let(:privkey_bin) { Utils.hex_to_bin(privkey) }

--- a/spec/ckb/wallet_spec.rb
+++ b/spec/ckb/wallet_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe CKB::Wallet do
-  let(:privkey) { "0xe79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3" }
+  let(:privkey) { ENV["BOB_PRIVATE_KEY"]}
   let(:key) { CKB::Key.new(privkey) }
   let(:pubkey) { key.pubkey }
   let(:api) { nil }


### PR DESCRIPTION
# [v0.26.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.25.2...v0.26.0) (2019-12-16)


### Features

* update `get_cells_by_lock_hash` and `get_live_cells_by_lock` returns ([65f76c4](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/65f76c48ce91752442aa68dc57af0a9a7061ac9e))