### PR TITLE
[ᚬmaster] Rc/v0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [v0.26.1](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.26.0...v0.26.1) (2020-01-02)
+
+
+### Features
+
+* add `get_capacity_by_lock_hash` RPC ([9de8da2](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/9de8da23ec14f83178b72efa1a831973cad73cf8))
+
+
 # [v0.26.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.25.2...v0.26.0) (2019-12-16)
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ckb-sdk-ruby (0.26.0)
+    ckb-sdk-ruby (0.26.1)
       bitcoin-secp256k1 (~> 0.5.2)
       net-http-persistent (~> 3.0.0)
       rbnacl (~> 6.0, >= 6.0.1)

--- a/lib/ckb/api.rb
+++ b/lib/ckb/api.rb
@@ -269,6 +269,14 @@ module CKB
       Types::LockHashIndexState.from_h(state)
     end
 
+    # @param lock_hash [String]
+    #
+    # @return [CKB::Types::LockHashCapacity]
+    def get_capacity_by_lock_hash(lock_hash)
+      result = rpc.get_capacity_by_lock_hash(lock_hash)
+      Types::LockHashCapacity.from_h(result) unless result.nil?
+    end
+
     # @param block_hash [String] 0x...
     #
     # @return [CKB::Types::BlockHeader]

--- a/lib/ckb/rpc.rb
+++ b/lib/ckb/rpc.rb
@@ -147,6 +147,11 @@ module CKB
       rpc_request("index_lock_hash", params: [lock_hash, Utils.to_hex(index_from)])
     end
 
+    # @param lock_hash [String]
+    def get_capacity_by_lock_hash(lock_hash)
+      rpc_request('get_capacity_by_lock_hash', params: [lock_hash])
+    end
+
     def get_header(block_hash)
       rpc_request("get_header", params: [block_hash])
     end

--- a/lib/ckb/types/lock_hash_capacity.rb
+++ b/lib/ckb/types/lock_hash_capacity.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module CKB
+  module Types
+    class LockHashCapacity
+      attr_accessor :capacity, :cells_count, :block_number
+
+      # @param capacity [String | Integer] integer or hex number
+      # @param cells_count [String | Integer] integer or hex number
+      # @param block_number [String | Integer] integer or hex number
+      def initialize(capacity:, cells_count:, block_number:)
+        @capacity = Utils.to_int(capacity)
+        @cells_count = Utils.to_int(cells_count)
+        @block_number = Utils.to_int(block_number)
+      end
+
+      def to_h
+        {
+          capacity: Utils.to_hex(@capacity),
+          cells_count: Utils.to_hex(@cells_count),
+          block_number: Utils.to_hex(@block_number)
+        }
+      end
+
+      def self.from_h(hash)
+        return if hash.nil?
+
+        new(
+          capacity: hash[:capacity],
+          cells_count: hash[:cells_count],
+          block_number: hash[:block_number]
+        )
+      end
+    end
+  end
+end

--- a/lib/ckb/types/types.rb
+++ b/lib/ckb/types/types.rb
@@ -35,6 +35,7 @@ require_relative "cellbase_template"
 require_relative "block_template"
 require_relative "estimate_result"
 require_relative "witness"
+require_relative "lock_hash_capacity"
 
 module CKB
   module Types

--- a/lib/ckb/version.rb
+++ b/lib/ckb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CKB
-  VERSION = "0.26.0"
+  VERSION = "0.26.1"
 end

--- a/spec/ckb/api_spec.rb
+++ b/spec/ckb/api_spec.rb
@@ -180,6 +180,12 @@ RSpec.describe CKB::API do
       result = api.get_transactions_by_lock_hash(lock_hash, 0, 10)
       expect(result).not_to be nil
     end
+
+    it "get_capacity_by_lock_hash" do
+      api.index_lock_hash(lock_hash)
+      result = api.get_capacity_by_lock_hash(lock_hash)
+      expect(result).not_to be nil
+    end
   end
 
   it "get block header" do

--- a/spec/ckb/rpc_spec.rb
+++ b/spec/ckb/rpc_spec.rb
@@ -147,6 +147,12 @@ RSpec.describe CKB::RPC do
       result = rpc.get_transactions_by_lock_hash(lock_hash, 0, 10)
       expect(result).not_to be nil
     end
+
+    it "get_capacity_by_lock_hash" do
+      rpc.index_lock_hash(lock_hash)
+      result = rpc.get_capacity_by_lock_hash(lock_hash)
+      expect(result).not_to be nil
+    end
   end
 
   it "get block header" do

--- a/spec/ckb/types/lock_hash_capacity_spec.rb
+++ b/spec/ckb/types/lock_hash_capacity_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe CKB::Types::LockHashCapacity do
+  let(:lock_hash_capacity_h) do
+    {
+      "block_number": "0x400",
+      "capacity": "0xb00fb84df292",
+      "cells_count": "0x3f5"
+    }
+  end
+
+  let(:lock_hash_capacity) { CKB::Types::LockHashCapacity.from_h(lock_hash_capacity_h) }
+
+  it "from_h" do
+    expect(lock_hash_capacity).to be_a(CKB::Types::LockHashCapacity)
+    expect(lock_hash_capacity.capacity).to eq lock_hash_capacity_h[:capacity].hex
+    expect(lock_hash_capacity.cells_count).to eq lock_hash_capacity_h[:cells_count].hex
+    expect(lock_hash_capacity.block_number).to eq lock_hash_capacity_h[:block_number].hex
+  end
+
+  it "to_h" do
+    expect(
+      lock_hash_capacity.to_h
+    ).to eq lock_hash_capacity_h
+  end
+end


### PR DESCRIPTION
# [v0.26.1](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.26.0...v0.26.1) (2020-01-02)


### Features

* add `get_capacity_by_lock_hash` RPC ([9de8da2](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/9de8da23ec14f83178b72efa1a831973cad73cf8))