### PR TITLE
[ᚬmaster] Rc/v0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Features
 
-* update send_transaction rpc ([295869f](https://github.com/shaojunda/ckb-sdk-ruby/commit/295869f))
+* update send_transaction rpc ([295869f](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/295869f))
 
 
 ### BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# [v0.27.1](https://github.com/shaojunda/ckb-sdk-ruby/compare/v0.26.1...v0.27.1) (2020-02-04)
+
+
+### Features
+
+* update send_transaction rpc ([295869f](https://github.com/shaojunda/ckb-sdk-ruby/commit/295869f))
+
+
+### BREAKING CHANGES
+
+* add outputs_validator to send_transaction rpc
+
+
+
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [v0.27.1](https://github.com/shaojunda/ckb-sdk-ruby/compare/v0.26.1...v0.27.1) (2020-02-04)
+# [v0.27.1](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.26.1...v0.27.1) (2020-02-04)
 
 
 ### Features

--- a/lib/ckb/api.rb
+++ b/lib/ckb/api.rb
@@ -152,8 +152,10 @@ module CKB
     # @param transaction [CKB::Types::Transaction]
     #
     # @return [String] tx_hash
-    def send_transaction(transaction)
-      rpc.send_transaction(transaction.to_raw_transaction_h)
+    def send_transaction(transaction, outputs_validator = "default")
+      raise ArgumentError, "Invalid outputs_validator, outputs_validator should be `default` or `passthrough`" unless %w(default passthrough).include?(outputs_validator)
+
+      rpc.send_transaction(transaction.to_raw_transaction_h, outputs_validator)
     end
 
     def compute_transaction_hash(transaction)

--- a/lib/ckb/rpc.rb
+++ b/lib/ckb/rpc.rb
@@ -73,8 +73,10 @@ module CKB
       rpc_request("get_live_cell", params: [out_point, with_data])
     end
 
-    def send_transaction(transaction)
-      rpc_request("send_transaction", params: [transaction])
+    def send_transaction(transaction, outputs_validator = "default")
+      raise ArgumentError, "Invalid outputs_validator, outputs_validator should be `default` or `passthrough`" unless %w(default passthrough).include?(outputs_validator)
+
+      rpc_request("send_transaction", params: [transaction, outputs_validator])
     end
 
     def local_node_info

--- a/lib/ckb/wallet.rb
+++ b/lib/ckb/wallet.rb
@@ -123,9 +123,9 @@ module CKB
     # @param data [String] "0x..."
     # @param key [CKB::Key | String] Key or private key hex string
     # @param fee [Integer] transaction fee, in shannon
-    def send_capacity(target_address, capacity, data = "0x", key: nil, fee: 0)
+    def send_capacity(target_address, capacity, data = "0x", key: nil, fee: 0, outputs_validator: "default")
       tx = generate_tx(target_address, capacity, data, key: key, fee: fee)
-      send_transaction(tx)
+      send_transaction(tx, outputs_validator)
     end
 
     # @param capacity [Integer]
@@ -360,8 +360,8 @@ args = #{lock.args}
     private
 
     # @param transaction [CKB::Transaction]
-    def send_transaction(transaction)
-      api.send_transaction(transaction)
+    def send_transaction(transaction, outputs_validator = "default")
+      api.send_transaction(transaction, outputs_validator)
     end
 
     # @param capacity [Integer]

--- a/spec/ckb/api_spec.rb
+++ b/spec/ckb/api_spec.rb
@@ -33,6 +33,56 @@ RSpec.describe CKB::API do
                 dao: "0x04d0a006e1840700df5d55f5358723001206877a0b00000000e3bad4847a0100" } }
   end
 
+  let(:normal_tx) do
+    {
+      "version": "0x0",
+      "cell_deps": [
+        {
+          "out_point": {
+            "tx_hash": "0xace5ea83c478bb866edf122ff862085789158f5cbff155b7bb5f13058555b708",
+            "index": "0x0"
+          },
+          "dep_type": "dep_group"
+        }
+      ],
+      "header_deps": [],
+      "inputs": [
+        {
+          "previous_output": {
+            "tx_hash": "0x3ac0a667dc308a78f38c75cbeedfdea9247bbd67e727e1c153a4aa1a2afb28d8",
+            "index": "0x0"
+          },
+          "since": "0x0"
+        }
+      ],
+      "outputs": [
+        {
+          "capacity": "0x174876e800",
+          "lock": {
+            "code_hash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+            "args": "0xe2193df51d78411601796b35b17b4f8f2cd85bd0",
+            "hash_type": "type"
+          },
+          "type": nil
+        },
+        {
+          "capacity": "0x123057115561",
+          "lock": {
+            "code_hash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+            "args": "0x36c329ed630d6ce750712a477543672adab57f4c",
+            "hash_type": "type"
+          },
+          "type": nil
+        }
+      ],
+      "outputs_data": [
+        "0x",
+        "0x"
+      ],
+      "witnesses": ["0x5500000010000000550000005500000041000000fd8d32a3e1a4276d479379357d8dda72f68672db9a21919bdc6f24d7b91cc6de5e7f76b835b9038303d9cae171ab47428eabdfa310d09254b8fadae19026605300"]
+    }
+  end
+
   it "genesis block" do
     expect(api.genesis_block).to be_a(Types::Block)
   end
@@ -100,6 +150,18 @@ RSpec.describe CKB::API do
     expect do
       api.send_transaction(tx)
     end.to raise_error(CKB::RPCError, /:code=>-3/)
+  end
+
+  it "should raise ArgumentError when outputs_validator is invalid" do
+    expect do
+      api.send_transaction(normal_tx, "something")
+    end.to raise_error(ArgumentError, "Invalid outputs_validator, outputs_validator should be `default` or `passthrough`")
+  end
+
+  it "should not raise ArgumentError when outputs_validator is valid" do
+    expect do
+      api.send_transaction(normal_tx, "passthrough")
+    end.not_to raise_error(ArgumentError, "Invalid outputs_validator, outputs_validator should be `default` or `passthrough`")
   end
 
   it "get current epoch" do

--- a/spec/ckb/rpc_spec.rb
+++ b/spec/ckb/rpc_spec.rb
@@ -29,6 +29,55 @@ RSpec.describe CKB::RPC do
   end
   let(:rpc) { CKB::RPC.new }
   let(:lock_hash) { "0xd0e22f863da970a3ff51a937ae78ba490bbdcede7272d658a053b9f80e30305d" }
+  let(:normal_tx) do
+    {
+      "version": "0x0",
+      "cell_deps": [
+        {
+          "out_point": {
+            "tx_hash": "0xace5ea83c478bb866edf122ff862085789158f5cbff155b7bb5f13058555b708",
+            "index": "0x0"
+          },
+          "dep_type": "dep_group"
+        }
+      ],
+      "header_deps": [],
+      "inputs": [
+        {
+          "previous_output": {
+            "tx_hash": "0x3ac0a667dc308a78f38c75cbeedfdea9247bbd67e727e1c153a4aa1a2afb28d8",
+            "index": "0x0"
+          },
+          "since": "0x0"
+        }
+      ],
+      "outputs": [
+        {
+          "capacity": "0x174876e800",
+          "lock": {
+            "code_hash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+            "args": "0xe2193df51d78411601796b35b17b4f8f2cd85bd0",
+            "hash_type": "type"
+          },
+          "type": nil
+        },
+        {
+          "capacity": "0x123057115561",
+          "lock": {
+            "code_hash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+            "args": "0x36c329ed630d6ce750712a477543672adab57f4c",
+            "hash_type": "type"
+          },
+          "type": nil
+        }
+      ],
+      "outputs_data": [
+        "0x",
+        "0x"
+      ],
+      "witnesses": ["0x5500000010000000550000005500000041000000fd8d32a3e1a4276d479379357d8dda72f68672db9a21919bdc6f24d7b91cc6de5e7f76b835b9038303d9cae171ab47428eabdfa310d09254b8fadae19026605300"]
+    }
+  end
 
   it "genesis block" do
     result = rpc.genesis_block
@@ -106,6 +155,18 @@ RSpec.describe CKB::RPC do
     expect do
       rpc.send_transaction(tx)
     end.to raise_error(CKB::RPCError, /:code=>-3/)
+  end
+
+  it "should raise ArgumentError when outputs_validator is invalid" do
+    expect do
+      rpc.send_transaction(normal_tx, "something")
+    end.to raise_error(ArgumentError, "Invalid outputs_validator, outputs_validator should be `default` or `passthrough`")
+  end
+
+  it "should not raise ArgumentError when outputs_validator is valid" do
+    expect do
+      rpc.send_transaction(normal_tx, "passthrough")
+    end.not_to raise_error(ArgumentError, "Invalid outputs_validator, outputs_validator should be `default` or `passthrough`")
   end
 
   it "local node info" do


### PR DESCRIPTION
### Features

* update send_transaction rpc ([295869f](https://github.com/shaojunda/ckb-sdk-ruby/commit/295869f))


### BREAKING CHANGES

* add outputs_validator to send_transaction rpc