### PR TITLE
chore: upgrade rbnacl to 7.1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ckb-sdk-ruby (0.33.0)
       bitcoin-secp256k1 (~> 0.5.2)
       net-http-persistent (~> 3.0.0)
-      rbnacl (~> 6.0, >= 6.0.1)
+      rbnacl (~> 7.1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -28,7 +28,7 @@ GEM
       method_source (~> 0.9.0)
     rainbow (3.0.0)
     rake (13.0.1)
-    rbnacl (6.0.1)
+    rbnacl (7.1.1)
       ffi
     rspec (3.9.0)
       rspec-core (~> 3.9.0)

--- a/ckb-sdk-ruby.gemspec
+++ b/ckb-sdk-ruby.gemspec
@@ -42,6 +42,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.12.2"
 
   spec.add_dependency "net-http-persistent", "~> 3.0.0"
-  spec.add_dependency "rbnacl", "~> 6.0", ">= 6.0.1"
+  spec.add_dependency "rbnacl", "~> 7.1.1"
   spec.add_dependency "bitcoin-secp256k1", "~> 0.5.2"
 end


### PR DESCRIPTION
Resolve ffi deprecation warning

```ruby
[DEPRECATION] Struct layout is already defined for class RbNaCl::HMAC::State. Redefinition as in /.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rbnacl-6.0.1/lib/rbnacl/hmac/sha512256.rb:103:in `<class:State>' will be disallowed in ffi-2.0.
[DEPRECATION] Struct layout is already defined for class RbNaCl::HMAC::State. Redefinition as in /.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rbnacl-6.0.1/lib/rbnacl/hmac/sha512.rb:105:in `<class:State>' will be disallowed in ffi-2.0.
```