### PR TITLE
Rc/v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# [v0.35.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.34.0...v0.35.0) (2020-08-25)
+
+
+### Features
+
+* add local_node and local_node_protocol ([0698992](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/0698992))
+* add more fields to peer ([4edf799](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/4edf799))
+* add remove_node and add_node RPC ([d943de2](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/d943de2))
+* add set_network_active RPC ([6cfced3](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/6cfced3))
+* add sync_state RPC ([4607b4c](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/4607b4c))
+* add tip info to tx_pool_info RPC ([d208f1f](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/d208f1f))
+
+
+
 # [v0.34.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.33.0...v0.34.0) (2020-07-21)
 
 


### PR DESCRIPTION
# [v0.35.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.34.0...v0.35.0) (2020-08-25)


### Features

* add local_node and local_node_protocol ([0698992](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/0698992))
* add more fields to peer ([4edf799](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/4edf799))
* add remove_node and add_node RPC ([d943de2](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/d943de2))
* add set_network_active RPC ([6cfced3](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/6cfced3))
* add sync_state RPC ([4607b4c](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/4607b4c))
* add tip info to tx_pool_info RPC ([d208f1f](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/d208f1f))