### PR TITLE
Rc/v0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# [v0.36.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.35.0...v0.36.0) (2020-09-21)
+
+* add deprecated warning on methods in Indexer module ([97f2f47](https://github.com/shaojunda/ckb-sdk-ruby/commit/97f2f47))
+
+
+### BREAKING CHANGES
+
+* deprecate methods in Indexer module
+
+
+
 # [v0.35.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.34.0...v0.35.0) (2020-08-25)
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ckb-sdk-ruby (0.35.0)
+    ckb-sdk-ruby (0.36.0)
       bitcoin-secp256k1 (~> 0.5.2)
       net-http-persistent (~> 3.1.0)
       rbnacl (~> 7.1.1)

--- a/lib/ckb/api.rb
+++ b/lib/ckb/api.rb
@@ -243,6 +243,7 @@ module CKB
 
     # @param lock_hash [String]
     def deindex_lock_hash(lock_hash)
+      warn "[DEPRECATION] This method is deprecated since version 0.36.0 for reasons of flexibility, please use ckb-indexer as an alternate solution"
       rpc.deindex_lock_hash(lock_hash)
     end
 
@@ -253,12 +254,14 @@ module CKB
     #
     # @return [Types::LiveCell[]]
     def get_live_cells_by_lock_hash(lock_hash, page, per, reverse_order: false)
+      warn "[DEPRECATION] This method is deprecated since version 0.36.0 for reasons of flexibility, please use ckb-indexer as an alternate solution"
       result = rpc.get_live_cells_by_lock_hash(lock_hash, page, per, reverse_order)
       result.map { |live_cell| Types::LiveCell.from_h(live_cell) }
     end
 
     # @return [Types::LockHashIndexState[]]
     def get_lock_hash_index_states
+      warn "[DEPRECATION] This method is deprecated since version 0.36.0 for reasons of flexibility, please use ckb-indexer as an alternate solution"
       result = rpc.get_lock_hash_index_states
       result.map { |state| Types::LockHashIndexState.from_h(state) }
     end
@@ -270,6 +273,7 @@ module CKB
     #
     # @return [Types::CellTransaction[]]
     def get_transactions_by_lock_hash(lock_hash, page, per, reverse_order: false)
+      warn "[DEPRECATION] This method is deprecated since version 0.36.0 for reasons of flexibility, please use ckb-indexer as an alternate solution"
       result = rpc.get_transactions_by_lock_hash(lock_hash, page, per, reverse_order)
       result.map { |cell_tx| Types::CellTransaction.from_h(cell_tx) }
     end
@@ -279,6 +283,7 @@ module CKB
     #
     # @return [Types::LockHashIndexState]
     def index_lock_hash(lock_hash, index_from: 0)
+      warn "[DEPRECATION] This method is deprecated since version 0.36.0 for reasons of flexibility, please use ckb-indexer as an alternate solution"
       state = rpc.index_lock_hash(lock_hash, index_from)
       Types::LockHashIndexState.from_h(state)
     end
@@ -287,6 +292,7 @@ module CKB
     #
     # @return [CKB::Types::LockHashCapacity]
     def get_capacity_by_lock_hash(lock_hash)
+      warn "[DEPRECATION] This method is deprecated since version 0.36.0 for reasons of flexibility, please use ckb-indexer as an alternate solution"
       result = rpc.get_capacity_by_lock_hash(lock_hash)
       Types::LockHashCapacity.from_h(result) unless result.nil?
     end

--- a/lib/ckb/version.rb
+++ b/lib/ckb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CKB
-  VERSION = "0.35.0"
+  VERSION = "0.36.0"
 end


### PR DESCRIPTION
# [v0.36.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.35.0...v0.36.0) (2020-09-21)

* add deprecated warning on methods in Indexer module ([97f2f47](https://github.com/shaojunda/ckb-sdk-ruby/commit/97f2f47))


### BREAKING CHANGES

* deprecate methods in Indexer module
