### PR TITLE
Rc/v0.38.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# [v0.38.1](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.38.0...v0.38.1) (2020-11-25)
+
+
+### Features
+
+* support generate short payload acp address ([092a89f](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/092a89f))
+* support parse short payload acp address ([f747a30](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/f747a30))
+
+
+
 # [v0.38.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.37.0...v0.38.0) (2020-11-23)
 Bump version to v0.38.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ckb-sdk-ruby (0.38.0)
+    ckb-sdk-ruby (0.38.1)
       bitcoin-secp256k1 (~> 0.5.2)
       net-http-persistent (~> 3.1.0)
       rbnacl (~> 7.1.1)

--- a/README.md
+++ b/README.md
@@ -72,12 +72,15 @@ Send capacity
 # create api first
 api = CKB::API.new
 
+# create ckb-indexer api
+indexer_api = CKB::Indexer::API.new
+
 # create two wallet object
-bob = CKB::Wallet.from_hex(api, "0xe79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3")
-alice = CKB::Wallet.from_hex(api, "0x76e853efa8245389e33f6fe49dcbd359eb56be2f6c3594e12521d2a806d32156")
+bob = CKB::Wallet.from_hex(api, "0xe79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3", indexer_api: indexer_api)
+alice = CKB::Wallet.from_hex(api, "0x76e853efa8245389e33f6fe49dcbd359eb56be2f6c3594e12521d2a806d32156", indexer_api: indexer_api)
 
 # bob send 1000 bytes to alice
-tx_hash = bob.send_capacity(alice.address, 1000 * 10**8)
+tx_hash = bob.send_capacity(alice.address, 1000 * 10**8, fee: 1000)
 
 # loop up the transaction by tx_hash
 api.get_transaction(tx_hash)
@@ -87,9 +90,10 @@ Provide wallet with a public key
 
 ```ruby
 api = CKB::API.new
+indexer_api = CKB::Indexer::API.new
 
-bob = CKB::Wallet.new(api, "0x024a501efd328e062c8675f2365970728c859c592beeefd6be8ead3d901330bc01")
-alice = CKB::Wallet.new(api, "0x0257623ec521657a27204c5590384cd59d9267c06d75ab308070be692251b67c57")
+bob = CKB::Wallet.new(api, "0x024a501efd328e062c8675f2365970728c859c592beeefd6be8ead3d901330bc01", indexer_api: indexer_api)
+alice = CKB::Wallet.new(api, "0x0257623ec521657a27204c5590384cd59d9267c06d75ab308070be692251b67c57", indexer_api: indexer_api)
 
 bob_key = "0xe79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3"
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,22 +1,7 @@
-# [v0.37.0](https://github.com/shaojunda/ckb-sdk-ruby/compare/v0.36.0...v0.37.0) (2020-10-27)
-
-
-### Code Refactoring
-
-* use ckb-indexer replace get_cells_by_lock_hash RPC ([2a62ce3](https://github.com/shaojunda/ckb-sdk-ruby/commit/2a62ce3))
+# [v0.38.1](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.38.0...v0.38.1) (2020-11-25)
 
 
 ### Features
 
-* add ckb-indexer types and get_cells api ([92ca150](https://github.com/shaojunda/ckb-sdk-ruby/commit/92ca150))
-* add more types ([bfd881c](https://github.com/shaojunda/ckb-sdk-ruby/commit/bfd881c))
-* add new RPCs ([48626ca](https://github.com/shaojunda/ckb-sdk-ruby/commit/48626ca))
-* remove RPC get_cells_by_lock_hash ([a935a7c](https://github.com/shaojunda/ckb-sdk-ruby/commit/a935a7c))
-
-
-### BREAKING CHANGES
-
-* use ckb-indexer replace get_cells_by_lock_hash RPC on wallet and multi_sign_wallet
-* remove RPC get_cells_by_lock_hash
-
-
+* support generate short payload acp address ([092a89f](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/092a89f))
+* support parse short payload acp address ([f747a30](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/f747a30))

--- a/lib/ckb/indexer/api.rb
+++ b/lib/ckb/indexer/api.rb
@@ -6,7 +6,7 @@ module CKB
       attr_reader :rpc
       DEFAULT_LIMIT = 1000
 
-      def initialize(indexer_host, timeout_config = {})
+      def initialize(indexer_host = CKB::RPC::DEFAULT_INDEXER_URL, timeout_config = {})
         @rpc = CKB::RPC.new(host: indexer_host, timeout_config: timeout_config)
       end
 

--- a/lib/ckb/rpc.rb
+++ b/lib/ckb/rpc.rb
@@ -25,6 +25,7 @@ module CKB
     attr_reader :uri, :http
 
     DEFAULT_URL = "http://localhost:8114"
+    DEFAULT_INDEXER_URL = "http://localhost:8116"
 
     def initialize(host: DEFAULT_URL, timeout_config: {})
       @uri = URI(host)

--- a/lib/ckb/version.rb
+++ b/lib/ckb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CKB
-  VERSION = "0.38.0"
+  VERSION = "0.38.1"
 end


### PR DESCRIPTION
# [v0.38.1](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.38.0...v0.38.1) (2020-11-25)


### Features

* support generate short payload acp address ([092a89f](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/092a89f))
* support parse short payload acp address ([f747a30](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/f747a30))

