### PR TITLE
Rc/v0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# [v0.39.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.38.1...v0.39.0) (2021-01-12)
+
+
+### Features
+
+* add consensus related types ([d29fe4a](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/d29fe4a))
+* add get_consensus RPC ([88de068](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/88de068))
+* add get_raw_tx_pool RPC ([87479b5](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/87479b5))
+
+
+
 # [v0.38.1](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.38.0...v0.38.1) (2020-11-25)
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ckb-sdk-ruby (0.38.1)
+    ckb-sdk-ruby (0.39.0)
       bitcoin-secp256k1 (~> 0.5.2)
       net-http-persistent (~> 3.1.0)
       rbnacl (~> 7.1.1)
@@ -15,7 +15,7 @@ GEM
     coderay (1.1.2)
     connection_pool (2.2.3)
     diff-lcs (1.3)
-    ffi (1.13.1)
+    ffi (1.14.2)
     jaro_winkler (1.5.2)
     method_source (0.9.2)
     net-http-persistent (3.1.0)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,7 +1,9 @@
-# [v0.38.1](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.38.0...v0.38.1) (2020-11-25)
+# [v0.39.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.38.1...v0.39.0) (2021-01-12)
 
 
 ### Features
 
-* support generate short payload acp address ([092a89f](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/092a89f))
-* support parse short payload acp address ([f747a30](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/f747a30))
+* add consensus related types ([d29fe4a](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/d29fe4a))
+* add get_consensus RPC ([88de068](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/88de068))
+* add get_raw_tx_pool RPC ([87479b5](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/87479b5))
+

--- a/lib/ckb/address.rb
+++ b/lib/ckb/address.rb
@@ -13,7 +13,7 @@ module CKB
     CODE_HASH_INDEX_SINGLESIG = "00"
     CODE_HASH_INDEX_MULTISIG_SIG = "01"
     CODE_HASH_INDEX_ANYONE_CAN_PAY = "02"
-    SHORT_PAYLOAD_AVAILABLE_ARGS_LEN = [20, 21, 22]
+    SHORT_PAYLOAD_AVAILABLE_ARGS_LEN = [20, 21, 22].freeze
 
     # @param script [CKB::Types::Script]
     # @param mode [String]
@@ -27,9 +27,10 @@ module CKB
     # payload = type(01) | code hash index(00) | pubkey blake160
     # see https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0021-ckb-address-format/0021-ckb-address-format.md for more info.
     def generate
-      unless CKB::ScriptHashType::TYPE == script.hash_type && script.has_args? && (SHORT_PAYLOAD_AVAILABLE_ARGS_LEN.include?(CKB::Utils.hex_to_bin(script.args).bytesize))
+      unless CKB::ScriptHashType::TYPE == script.hash_type && script.has_args? && SHORT_PAYLOAD_AVAILABLE_ARGS_LEN.include?(CKB::Utils.hex_to_bin(script.args).bytesize)
         return generate_full_payload_address
       end
+
       if SystemCodeHash::SECP256K1_BLAKE160_SIGHASH_ALL_TYPE_HASH == script.code_hash
         generate_short_payload_singlesig_address
       elsif SystemCodeHash::SECP256K1_BLAKE160_MULTISIG_ALL_TYPE_HASH == script.code_hash

--- a/lib/ckb/api.rb
+++ b/lib/ckb/api.rb
@@ -294,6 +294,10 @@ module CKB
       end
     end
 
+    def get_consensus
+      Types::Consensus.from_h(rpc.get_consensus)
+    end
+
     # @return sync_state [SyncState]
     def sync_state
       Types::SyncState.from_h(rpc.sync_state)

--- a/lib/ckb/api.rb
+++ b/lib/ckb/api.rb
@@ -8,22 +8,11 @@ require "uri"
 
 module CKB
   class API
-    attr_reader :rpc
-    attr_reader :secp_group_out_point
-    attr_reader :secp_code_out_point
-    attr_reader :secp_data_out_point
-    attr_reader :secp_cell_type_hash
-    attr_reader :secp_cell_code_hash
-    attr_reader :dao_out_point
-    attr_reader :dao_code_hash
-    attr_reader :dao_type_hash
-
-    attr_reader :multi_sign_secp_cell_type_hash
-    attr_reader :multi_sign_secp_group_out_point
+    attr_reader :rpc, :secp_group_out_point, :secp_code_out_point, :secp_data_out_point, :secp_cell_type_hash, :secp_cell_code_hash, :dao_out_point, :dao_code_hash, :dao_type_hash, :multi_sign_secp_cell_type_hash, :multi_sign_secp_group_out_point
 
     def initialize(host: CKB::RPC::DEFAULT_URL, mode: MODE::TESTNET, timeout_config: {})
       @rpc = CKB::RPC.new(host: host, timeout_config: timeout_config)
-      if mode == MODE::TESTNET || mode == MODE::MAINNET
+      if [MODE::TESTNET, MODE::MAINNET].include?(mode)
         # For testnet chain, we can assume the second cell of the first transaction
         # in the genesis block contains default lock script we can use here.
         system_cell_transaction = genesis_block.transactions.first
@@ -294,6 +283,15 @@ module CKB
 
     def clear_tx_pool
       rpc.clear_tx_pool
+    end
+
+    def get_raw_tx_pool(verbose = false)
+      rs = rpc.get_raw_tx_pool(verbose)
+      if verbose
+        Types::TxPoolVerbosity.from_h(rs)
+      else
+        Types::TxPoolIds.from_h(rs)
+      end
     end
 
     # @return sync_state [SyncState]

--- a/lib/ckb/indexer/api.rb
+++ b/lib/ckb/indexer/api.rb
@@ -4,6 +4,7 @@ module CKB
   module Indexer
     class API
       attr_reader :rpc
+
       DEFAULT_LIMIT = 1000
 
       def initialize(indexer_host = CKB::RPC::DEFAULT_INDEXER_URL, timeout_config = {})

--- a/lib/ckb/indexer/types/live_cells.rb
+++ b/lib/ckb/indexer/types/live_cells.rb
@@ -5,6 +5,7 @@ module CKB
     module Types
       class LiveCells
         attr_reader :last_cursor, :objects
+
         # @param last_cursor [String]
         # @param objects [CKB::Types::LiveCell[]]
         def initialize(last_cursor:, objects:)

--- a/lib/ckb/multi_sign_wallet.rb
+++ b/lib/ckb/multi_sign_wallet.rb
@@ -2,10 +2,7 @@
 
 module CKB
   class MultiSignConfiguration
-    attr_reader :require_n
-    attr_reader :threshold
-    attr_reader :pubkeys
-    attr_reader :since
+    attr_reader :require_n, :threshold, :pubkeys, :since
 
     def initialize(require_n:, threshold:, pubkeys:, since:)
       raise "require_n should be less than 256" if require_n > 255 || require_n < 0
@@ -48,11 +45,7 @@ module CKB
   end
 
   class MultiSignWallet
-    attr_reader :api
-    attr_reader :configuration
-    attr_reader :skip_data_and_type
-    attr_reader :prefix
-    attr_reader :indexer_api
+    attr_reader :api, :configuration, :skip_data_and_type, :prefix, :indexer_api
 
     def initialize(api, configuration, skip_data_and_type: true, prefix: CKB::Address::PREFIX_TESTNET, indexer_api: nil)
       @api = api

--- a/lib/ckb/serializers/script_serializer.rb
+++ b/lib/ckb/serializers/script_serializer.rb
@@ -18,13 +18,11 @@ module CKB
 
       def init_args(script)
         args = script.args
-        args = if args
-                 args.start_with?("0x") ? args[2..-1] : args
-               else
-                 ""
-               end
-
-        args
+        if args
+          args.start_with?("0x") ? args[2..-1] : args
+        else
+          ""
+        end
       end
 
       attr_reader :code_hash_serializer, :hash_type_serializer, :args_serializer, :items_count

--- a/lib/ckb/types/cell_info.rb
+++ b/lib/ckb/types/cell_info.rb
@@ -7,7 +7,7 @@ module CKB
 
       # @param output [CKB::Types::Output]
       # @param data [CKB::Types::CellData | nil]
-      def initialize(output: nil, data:)
+      def initialize(data:, output: nil)
         @output = output
         @data = data
       end

--- a/lib/ckb/types/consensus.rb
+++ b/lib/ckb/types/consensus.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+#
+module CKB
+	module Types
+		class Consensus
+			attr_accessor :id, :genesis_hash, :dao_type_hash, :secp256k1_blake160_sighash_all_type_hash, :secp256k1_blake160_multisig_all_type_hash, :initial_primary_epoch_reward, :secondary_epoch_reward, :max_uncles_num,
+										:orphan_rate_target, :epoch_duration_target, :tx_proposal_window, :proposer_reward_ratio, :cellbase_maturity, :median_time_block_count, :max_block_cycles, :max_block_bytes, :block_version, :tx_version,
+										:type_id_code_hash, :max_block_proposals_limit, :primary_epoch_reward_halving_interval, :permanent_difficulty_in_dummy
+
+			# @param id [String]
+			# @param genesis_hash [String]
+			# @param dao_type_hash [String]
+			# @param secp256k1_blake160_sighash_all_type_hash [String]
+			# @param secp256k1_blake160_multisig_all_type_hash [String]
+			# @param initial_primary_epoch_reward [Integer | String]
+			# @param secondary_epoch_reward [Integer | String]
+			# @param max_uncles_num [Integer | String]
+			# @param orphan_rate_target [CKB::Types::RationalU256]
+			# @param epoch_duration_target [Integer | String]
+			# @param tx_proposal_window [CKB::Types::ProposalWindow]
+			# @param proposer_reward_ratio [CKB::Types::RationalU256]
+			# @param cellbase_maturity [String]
+			# @param median_time_block_count [Integer | String]
+			# @param max_block_cycles [Integer | String]
+			# @param max_block_bytes [Integer | String]
+			# @param block_version [Integer | String]
+			# @param tx_version [Integer | String]
+			# @param type_id_code_hash [String]
+			# @param max_block_proposals_limit [Integer | String]
+			# @param primary_epoch_reward_halving_interval [Integer | String]
+			# @param permanent_difficulty_in_dummy [Boolean]
+			def initialize(id:, genesis_hash:, dao_type_hash:, secp256k1_blake160_sighash_all_type_hash:, secp256k1_blake160_multisig_all_type_hash:, initial_primary_epoch_reward:, secondary_epoch_reward:, max_uncles_num:, orphan_rate_target:, epoch_duration_target:,
+			               tx_proposal_window:, proposer_reward_ratio:, cellbase_maturity:, median_time_block_count:, max_block_cycles:, max_block_bytes:, block_version:, tx_version:, type_id_code_hash:, max_block_proposals_limit:, primary_epoch_reward_halving_interval:, permanent_difficulty_in_dummy:)
+				@id = id
+				@genesis_hash = genesis_hash
+				@dao_type_hash = dao_type_hash
+				@secp256k1_blake160_sighash_all_type_hash = secp256k1_blake160_sighash_all_type_hash
+				@secp256k1_blake160_multisig_all_type_hash = secp256k1_blake160_multisig_all_type_hash
+				@initial_primary_epoch_reward = CKB::Utils.to_int(initial_primary_epoch_reward)
+				@secondary_epoch_reward = CKB::Utils.to_int(secondary_epoch_reward)
+				@max_uncles_num = CKB::Utils.to_int(max_uncles_num)
+				@orphan_rate_target = orphan_rate_target
+				@epoch_duration_target = CKB::Utils.to_int(epoch_duration_target)
+				@tx_proposal_window = tx_proposal_window
+				@proposer_reward_ratio = proposer_reward_ratio
+				@cellbase_maturity = cellbase_maturity
+				@median_time_block_count = CKB::Utils.to_int(median_time_block_count)
+				@max_block_cycles = CKB::Utils.to_int(max_block_cycles)
+				@max_block_bytes = CKB::Utils.to_int(max_block_bytes)
+				@block_version = CKB::Utils.to_int(block_version)
+				@tx_version = CKB::Utils.to_int(tx_version)
+				@type_id_code_hash = type_id_code_hash
+				@max_block_proposals_limit = CKB::Utils.to_int(max_block_proposals_limit)
+				@primary_epoch_reward_halving_interval = CKB::Utils.to_int(primary_epoch_reward_halving_interval)
+				@permanent_difficulty_in_dummy = permanent_difficulty_in_dummy
+			end
+
+			def to_h
+				{
+					id: id,
+					genesis_hash: genesis_hash,
+					dao_type_hash: dao_type_hash,
+					secp256k1_blake160_sighash_all_type_hash: secp256k1_blake160_sighash_all_type_hash,
+					secp256k1_blake160_multisig_all_type_hash: secp256k1_blake160_multisig_all_type_hash,
+					initial_primary_epoch_reward: CKB::Utils.to_hex(initial_primary_epoch_reward),
+					secondary_epoch_reward: CKB::Utils.to_hex(secondary_epoch_reward),
+					max_uncles_num: CKB::Utils.to_hex(max_uncles_num),
+					orphan_rate_target: orphan_rate_target.to_h,
+					epoch_duration_target: CKB::Utils.to_hex(epoch_duration_target),
+					tx_proposal_window: tx_proposal_window.to_h,
+					proposer_reward_ratio: proposer_reward_ratio.to_h,
+					cellbase_maturity: cellbase_maturity,
+					median_time_block_count: CKB::Utils.to_hex(median_time_block_count),
+					max_block_cycles: CKB::Utils.to_hex(max_block_cycles),
+					max_block_bytes: CKB::Utils.to_hex(max_block_bytes),
+					block_version: CKB::Utils.to_hex(block_version),
+					tx_version: CKB::Utils.to_hex(tx_version),
+					type_id_code_hash: type_id_code_hash,
+					max_block_proposals_limit: CKB::Utils.to_hex(max_block_proposals_limit),
+					primary_epoch_reward_halving_interval: CKB::Utils.to_hex(primary_epoch_reward_halving_interval),
+					permanent_difficulty_in_dummy: permanent_difficulty_in_dummy
+				}
+			end
+
+			def self.from_h(hash)
+				return if hash.nil?
+
+				new(
+					id: hash[:id],
+					genesis_hash: hash[:genesis_hash],
+					dao_type_hash: hash[:dao_type_hash],
+					secp256k1_blake160_sighash_all_type_hash: hash[:secp256k1_blake160_sighash_all_type_hash],
+					secp256k1_blake160_multisig_all_type_hash: hash[:secp256k1_blake160_multisig_all_type_hash],
+					initial_primary_epoch_reward: hash[:initial_primary_epoch_reward],
+					secondary_epoch_reward: hash[:secondary_epoch_reward],
+					max_uncles_num: hash[:max_uncles_num],
+					orphan_rate_target: CKB::Types::RationalU256.from_h(hash[:orphan_rate_target]),
+					epoch_duration_target: hash[:epoch_duration_target],
+					tx_proposal_window: CKB::Types::ProposalWindow.from_h(hash[:tx_proposal_window]),
+					proposer_reward_ratio: CKB::Types::RationalU256.from_h(hash[:proposer_reward_ratio]),
+					cellbase_maturity: hash[:cellbase_maturity],
+					median_time_block_count: hash[:median_time_block_count],
+					max_block_cycles: hash[:max_block_cycles],
+					max_block_bytes: hash[:max_block_bytes],
+					block_version: hash[:block_version],
+					tx_version: hash[:tx_version],
+					type_id_code_hash: hash[:type_id_code_hash],
+					max_block_proposals_limit: hash[:max_block_proposals_limit],
+					primary_epoch_reward_halving_interval: hash[:primary_epoch_reward_halving_interval],
+					permanent_difficulty_in_dummy: hash[:permanent_difficulty_in_dummy]
+				)
+			end
+		end
+	end
+end
+

--- a/lib/ckb/types/consensus.rb
+++ b/lib/ckb/types/consensus.rb
@@ -1,116 +1,115 @@
 # frozen_string_literal: true
-#
+
 module CKB
-	module Types
-		class Consensus
-			attr_accessor :id, :genesis_hash, :dao_type_hash, :secp256k1_blake160_sighash_all_type_hash, :secp256k1_blake160_multisig_all_type_hash, :initial_primary_epoch_reward, :secondary_epoch_reward, :max_uncles_num,
-										:orphan_rate_target, :epoch_duration_target, :tx_proposal_window, :proposer_reward_ratio, :cellbase_maturity, :median_time_block_count, :max_block_cycles, :max_block_bytes, :block_version, :tx_version,
-										:type_id_code_hash, :max_block_proposals_limit, :primary_epoch_reward_halving_interval, :permanent_difficulty_in_dummy
+  module Types
+    class Consensus
+      attr_accessor :id, :genesis_hash, :dao_type_hash, :secp256k1_blake160_sighash_all_type_hash, :secp256k1_blake160_multisig_all_type_hash, :initial_primary_epoch_reward, :secondary_epoch_reward, :max_uncles_num,
+                    :orphan_rate_target, :epoch_duration_target, :tx_proposal_window, :proposer_reward_ratio, :cellbase_maturity, :median_time_block_count, :max_block_cycles, :max_block_bytes, :block_version, :tx_version,
+                    :type_id_code_hash, :max_block_proposals_limit, :primary_epoch_reward_halving_interval, :permanent_difficulty_in_dummy
 
-			# @param id [String]
-			# @param genesis_hash [String]
-			# @param dao_type_hash [String]
-			# @param secp256k1_blake160_sighash_all_type_hash [String]
-			# @param secp256k1_blake160_multisig_all_type_hash [String]
-			# @param initial_primary_epoch_reward [Integer | String]
-			# @param secondary_epoch_reward [Integer | String]
-			# @param max_uncles_num [Integer | String]
-			# @param orphan_rate_target [CKB::Types::RationalU256]
-			# @param epoch_duration_target [Integer | String]
-			# @param tx_proposal_window [CKB::Types::ProposalWindow]
-			# @param proposer_reward_ratio [CKB::Types::RationalU256]
-			# @param cellbase_maturity [String]
-			# @param median_time_block_count [Integer | String]
-			# @param max_block_cycles [Integer | String]
-			# @param max_block_bytes [Integer | String]
-			# @param block_version [Integer | String]
-			# @param tx_version [Integer | String]
-			# @param type_id_code_hash [String]
-			# @param max_block_proposals_limit [Integer | String]
-			# @param primary_epoch_reward_halving_interval [Integer | String]
-			# @param permanent_difficulty_in_dummy [Boolean]
-			def initialize(id:, genesis_hash:, dao_type_hash:, secp256k1_blake160_sighash_all_type_hash:, secp256k1_blake160_multisig_all_type_hash:, initial_primary_epoch_reward:, secondary_epoch_reward:, max_uncles_num:, orphan_rate_target:, epoch_duration_target:,
-			               tx_proposal_window:, proposer_reward_ratio:, cellbase_maturity:, median_time_block_count:, max_block_cycles:, max_block_bytes:, block_version:, tx_version:, type_id_code_hash:, max_block_proposals_limit:, primary_epoch_reward_halving_interval:, permanent_difficulty_in_dummy:)
-				@id = id
-				@genesis_hash = genesis_hash
-				@dao_type_hash = dao_type_hash
-				@secp256k1_blake160_sighash_all_type_hash = secp256k1_blake160_sighash_all_type_hash
-				@secp256k1_blake160_multisig_all_type_hash = secp256k1_blake160_multisig_all_type_hash
-				@initial_primary_epoch_reward = CKB::Utils.to_int(initial_primary_epoch_reward)
-				@secondary_epoch_reward = CKB::Utils.to_int(secondary_epoch_reward)
-				@max_uncles_num = CKB::Utils.to_int(max_uncles_num)
-				@orphan_rate_target = orphan_rate_target
-				@epoch_duration_target = CKB::Utils.to_int(epoch_duration_target)
-				@tx_proposal_window = tx_proposal_window
-				@proposer_reward_ratio = proposer_reward_ratio
-				@cellbase_maturity = cellbase_maturity
-				@median_time_block_count = CKB::Utils.to_int(median_time_block_count)
-				@max_block_cycles = CKB::Utils.to_int(max_block_cycles)
-				@max_block_bytes = CKB::Utils.to_int(max_block_bytes)
-				@block_version = CKB::Utils.to_int(block_version)
-				@tx_version = CKB::Utils.to_int(tx_version)
-				@type_id_code_hash = type_id_code_hash
-				@max_block_proposals_limit = CKB::Utils.to_int(max_block_proposals_limit)
-				@primary_epoch_reward_halving_interval = CKB::Utils.to_int(primary_epoch_reward_halving_interval)
-				@permanent_difficulty_in_dummy = permanent_difficulty_in_dummy
-			end
+      # @param id [String]
+      # @param genesis_hash [String]
+      # @param dao_type_hash [String]
+      # @param secp256k1_blake160_sighash_all_type_hash [String]
+      # @param secp256k1_blake160_multisig_all_type_hash [String]
+      # @param initial_primary_epoch_reward [Integer | String]
+      # @param secondary_epoch_reward [Integer | String]
+      # @param max_uncles_num [Integer | String]
+      # @param orphan_rate_target [CKB::Types::RationalU256]
+      # @param epoch_duration_target [Integer | String]
+      # @param tx_proposal_window [CKB::Types::ProposalWindow]
+      # @param proposer_reward_ratio [CKB::Types::RationalU256]
+      # @param cellbase_maturity [String]
+      # @param median_time_block_count [Integer | String]
+      # @param max_block_cycles [Integer | String]
+      # @param max_block_bytes [Integer | String]
+      # @param block_version [Integer | String]
+      # @param tx_version [Integer | String]
+      # @param type_id_code_hash [String]
+      # @param max_block_proposals_limit [Integer | String]
+      # @param primary_epoch_reward_halving_interval [Integer | String]
+      # @param permanent_difficulty_in_dummy [Boolean]
+      def initialize(id:, genesis_hash:, dao_type_hash:, secp256k1_blake160_sighash_all_type_hash:, secp256k1_blake160_multisig_all_type_hash:, initial_primary_epoch_reward:, secondary_epoch_reward:, max_uncles_num:, orphan_rate_target:, epoch_duration_target:,
+                     tx_proposal_window:, proposer_reward_ratio:, cellbase_maturity:, median_time_block_count:, max_block_cycles:, max_block_bytes:, block_version:, tx_version:, type_id_code_hash:, max_block_proposals_limit:, primary_epoch_reward_halving_interval:, permanent_difficulty_in_dummy:)
+        @id = id
+        @genesis_hash = genesis_hash
+        @dao_type_hash = dao_type_hash
+        @secp256k1_blake160_sighash_all_type_hash = secp256k1_blake160_sighash_all_type_hash
+        @secp256k1_blake160_multisig_all_type_hash = secp256k1_blake160_multisig_all_type_hash
+        @initial_primary_epoch_reward = CKB::Utils.to_int(initial_primary_epoch_reward)
+        @secondary_epoch_reward = CKB::Utils.to_int(secondary_epoch_reward)
+        @max_uncles_num = CKB::Utils.to_int(max_uncles_num)
+        @orphan_rate_target = orphan_rate_target
+        @epoch_duration_target = CKB::Utils.to_int(epoch_duration_target)
+        @tx_proposal_window = tx_proposal_window
+        @proposer_reward_ratio = proposer_reward_ratio
+        @cellbase_maturity = cellbase_maturity
+        @median_time_block_count = CKB::Utils.to_int(median_time_block_count)
+        @max_block_cycles = CKB::Utils.to_int(max_block_cycles)
+        @max_block_bytes = CKB::Utils.to_int(max_block_bytes)
+        @block_version = CKB::Utils.to_int(block_version)
+        @tx_version = CKB::Utils.to_int(tx_version)
+        @type_id_code_hash = type_id_code_hash
+        @max_block_proposals_limit = CKB::Utils.to_int(max_block_proposals_limit)
+        @primary_epoch_reward_halving_interval = CKB::Utils.to_int(primary_epoch_reward_halving_interval)
+        @permanent_difficulty_in_dummy = permanent_difficulty_in_dummy
+      end
 
-			def to_h
-				{
-					id: id,
-					genesis_hash: genesis_hash,
-					dao_type_hash: dao_type_hash,
-					secp256k1_blake160_sighash_all_type_hash: secp256k1_blake160_sighash_all_type_hash,
-					secp256k1_blake160_multisig_all_type_hash: secp256k1_blake160_multisig_all_type_hash,
-					initial_primary_epoch_reward: CKB::Utils.to_hex(initial_primary_epoch_reward),
-					secondary_epoch_reward: CKB::Utils.to_hex(secondary_epoch_reward),
-					max_uncles_num: CKB::Utils.to_hex(max_uncles_num),
-					orphan_rate_target: orphan_rate_target.to_h,
-					epoch_duration_target: CKB::Utils.to_hex(epoch_duration_target),
-					tx_proposal_window: tx_proposal_window.to_h,
-					proposer_reward_ratio: proposer_reward_ratio.to_h,
-					cellbase_maturity: cellbase_maturity,
-					median_time_block_count: CKB::Utils.to_hex(median_time_block_count),
-					max_block_cycles: CKB::Utils.to_hex(max_block_cycles),
-					max_block_bytes: CKB::Utils.to_hex(max_block_bytes),
-					block_version: CKB::Utils.to_hex(block_version),
-					tx_version: CKB::Utils.to_hex(tx_version),
-					type_id_code_hash: type_id_code_hash,
-					max_block_proposals_limit: CKB::Utils.to_hex(max_block_proposals_limit),
-					primary_epoch_reward_halving_interval: CKB::Utils.to_hex(primary_epoch_reward_halving_interval),
-					permanent_difficulty_in_dummy: permanent_difficulty_in_dummy
-				}
-			end
+      def to_h
+        {
+          id: id,
+          genesis_hash: genesis_hash,
+          dao_type_hash: dao_type_hash,
+          secp256k1_blake160_sighash_all_type_hash: secp256k1_blake160_sighash_all_type_hash,
+          secp256k1_blake160_multisig_all_type_hash: secp256k1_blake160_multisig_all_type_hash,
+          initial_primary_epoch_reward: CKB::Utils.to_hex(initial_primary_epoch_reward),
+          secondary_epoch_reward: CKB::Utils.to_hex(secondary_epoch_reward),
+          max_uncles_num: CKB::Utils.to_hex(max_uncles_num),
+          orphan_rate_target: orphan_rate_target.to_h,
+          epoch_duration_target: CKB::Utils.to_hex(epoch_duration_target),
+          tx_proposal_window: tx_proposal_window.to_h,
+          proposer_reward_ratio: proposer_reward_ratio.to_h,
+          cellbase_maturity: cellbase_maturity,
+          median_time_block_count: CKB::Utils.to_hex(median_time_block_count),
+          max_block_cycles: CKB::Utils.to_hex(max_block_cycles),
+          max_block_bytes: CKB::Utils.to_hex(max_block_bytes),
+          block_version: CKB::Utils.to_hex(block_version),
+          tx_version: CKB::Utils.to_hex(tx_version),
+          type_id_code_hash: type_id_code_hash,
+          max_block_proposals_limit: CKB::Utils.to_hex(max_block_proposals_limit),
+          primary_epoch_reward_halving_interval: CKB::Utils.to_hex(primary_epoch_reward_halving_interval),
+          permanent_difficulty_in_dummy: permanent_difficulty_in_dummy
+        }
+      end
 
-			def self.from_h(hash)
-				return if hash.nil?
+      def self.from_h(hash)
+        return if hash.nil?
 
-				new(
-					id: hash[:id],
-					genesis_hash: hash[:genesis_hash],
-					dao_type_hash: hash[:dao_type_hash],
-					secp256k1_blake160_sighash_all_type_hash: hash[:secp256k1_blake160_sighash_all_type_hash],
-					secp256k1_blake160_multisig_all_type_hash: hash[:secp256k1_blake160_multisig_all_type_hash],
-					initial_primary_epoch_reward: hash[:initial_primary_epoch_reward],
-					secondary_epoch_reward: hash[:secondary_epoch_reward],
-					max_uncles_num: hash[:max_uncles_num],
-					orphan_rate_target: CKB::Types::RationalU256.from_h(hash[:orphan_rate_target]),
-					epoch_duration_target: hash[:epoch_duration_target],
-					tx_proposal_window: CKB::Types::ProposalWindow.from_h(hash[:tx_proposal_window]),
-					proposer_reward_ratio: CKB::Types::RationalU256.from_h(hash[:proposer_reward_ratio]),
-					cellbase_maturity: hash[:cellbase_maturity],
-					median_time_block_count: hash[:median_time_block_count],
-					max_block_cycles: hash[:max_block_cycles],
-					max_block_bytes: hash[:max_block_bytes],
-					block_version: hash[:block_version],
-					tx_version: hash[:tx_version],
-					type_id_code_hash: hash[:type_id_code_hash],
-					max_block_proposals_limit: hash[:max_block_proposals_limit],
-					primary_epoch_reward_halving_interval: hash[:primary_epoch_reward_halving_interval],
-					permanent_difficulty_in_dummy: hash[:permanent_difficulty_in_dummy]
-				)
-			end
-		end
-	end
+        new(
+          id: hash[:id],
+          genesis_hash: hash[:genesis_hash],
+          dao_type_hash: hash[:dao_type_hash],
+          secp256k1_blake160_sighash_all_type_hash: hash[:secp256k1_blake160_sighash_all_type_hash],
+          secp256k1_blake160_multisig_all_type_hash: hash[:secp256k1_blake160_multisig_all_type_hash],
+          initial_primary_epoch_reward: hash[:initial_primary_epoch_reward],
+          secondary_epoch_reward: hash[:secondary_epoch_reward],
+          max_uncles_num: hash[:max_uncles_num],
+          orphan_rate_target: CKB::Types::RationalU256.from_h(hash[:orphan_rate_target]),
+          epoch_duration_target: hash[:epoch_duration_target],
+          tx_proposal_window: CKB::Types::ProposalWindow.from_h(hash[:tx_proposal_window]),
+          proposer_reward_ratio: CKB::Types::RationalU256.from_h(hash[:proposer_reward_ratio]),
+          cellbase_maturity: hash[:cellbase_maturity],
+          median_time_block_count: hash[:median_time_block_count],
+          max_block_cycles: hash[:max_block_cycles],
+          max_block_bytes: hash[:max_block_bytes],
+          block_version: hash[:block_version],
+          tx_version: hash[:tx_version],
+          type_id_code_hash: hash[:type_id_code_hash],
+          max_block_proposals_limit: hash[:max_block_proposals_limit],
+          primary_epoch_reward_halving_interval: hash[:primary_epoch_reward_halving_interval],
+          permanent_difficulty_in_dummy: hash[:permanent_difficulty_in_dummy]
+        )
+      end
+    end
+  end
 end
-

--- a/lib/ckb/types/proposal_window.rb
+++ b/lib/ckb/types/proposal_window.rb
@@ -1,32 +1,32 @@
 # frozen_string_literal: true
 
 module CKB
-	module Types
-		class ProposalWindow
-			attr_accessor :closest, :farthest
+  module Types
+    class ProposalWindow
+      attr_accessor :closest, :farthest
 
-			# @param closest [Integer | String]
-			# @param farthest [Integer | String]
-			def initialize(closest:, farthest:)
-				@closest = CKB::Utils.to_int(closest)
-				@farthest = CKB::Utils.to_int(farthest)
-			end
+      # @param closest [Integer | String]
+      # @param farthest [Integer | String]
+      def initialize(closest:, farthest:)
+        @closest = CKB::Utils.to_int(closest)
+        @farthest = CKB::Utils.to_int(farthest)
+      end
 
-			def to_h
-				{
-					closest: CKB::Utils.to_hex(closest),
-					farthest: CKB::Utils.to_hex(farthest)
-				}
-			end
+      def to_h
+        {
+          closest: CKB::Utils.to_hex(closest),
+          farthest: CKB::Utils.to_hex(farthest)
+        }
+      end
 
-			def self.from_h(hash)
-				return if hash.nil?
+      def self.from_h(hash)
+        return if hash.nil?
 
-				new(
-					closest: hash[:closest],
-					farthest: hash[:farthest]
-				)
-			end
-		end
-	end
+        new(
+          closest: hash[:closest],
+          farthest: hash[:farthest]
+        )
+      end
+    end
+  end
 end

--- a/lib/ckb/types/proposal_window.rb
+++ b/lib/ckb/types/proposal_window.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module CKB
+	module Types
+		class ProposalWindow
+			attr_accessor :closest, :farthest
+
+			# @param closest [Integer | String]
+			# @param farthest [Integer | String]
+			def initialize(closest:, farthest:)
+				@closest = CKB::Utils.to_int(closest)
+				@farthest = CKB::Utils.to_int(farthest)
+			end
+
+			def to_h
+				{
+					closest: CKB::Utils.to_hex(closest),
+					farthest: CKB::Utils.to_hex(farthest)
+				}
+			end
+
+			def self.from_h(hash)
+				return if hash.nil?
+
+				new(
+					closest: hash[:closest],
+					farthest: hash[:farthest]
+				)
+			end
+		end
+	end
+end

--- a/lib/ckb/types/rational_u256.rb
+++ b/lib/ckb/types/rational_u256.rb
@@ -1,32 +1,32 @@
 # frozen_string_literal: true
 
 module CKB
-	module Types
-		class RationalU256
-			attr_accessor :denom, :numer
+  module Types
+    class RationalU256
+      attr_accessor :denom, :numer
 
-			# @param denom [String]
-			# @param numer [String]
-			def initialize(denom:, numer:)
-				@denom = denom
-				@numer = numer
-			end
+      # @param denom [String]
+      # @param numer [String]
+      def initialize(denom:, numer:)
+        @denom = denom
+        @numer = numer
+      end
 
-			def to_h
-				{
-					denom: denom,
-					numer: numer
-				}
-			end
+      def to_h
+        {
+          denom: denom,
+          numer: numer
+        }
+      end
 
-			def self.from_h(hash)
-				return if hash.nil?
+      def self.from_h(hash)
+        return if hash.nil?
 
-				new(
-					denom: hash[:denom],
-					numer: hash[:numer]
-				)
-			end
-		end
-	end
+        new(
+          denom: hash[:denom],
+          numer: hash[:numer]
+        )
+      end
+    end
+  end
 end

--- a/lib/ckb/types/rational_u256.rb
+++ b/lib/ckb/types/rational_u256.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module CKB
+	module Types
+		class RationalU256
+			attr_accessor :denom, :numer
+
+			# @param denom [String]
+			# @param numer [String]
+			def initialize(denom:, numer:)
+				@denom = denom
+				@numer = numer
+			end
+
+			def to_h
+				{
+					denom: denom,
+					numer: numer
+				}
+			end
+
+			def self.from_h(hash)
+				return if hash.nil?
+
+				new(
+					denom: hash[:denom],
+					numer: hash[:numer]
+				)
+			end
+		end
+	end
+end

--- a/lib/ckb/types/transaction.rb
+++ b/lib/ckb/types/transaction.rb
@@ -55,7 +55,7 @@ module CKB
                           Utils.hex_to_bin(CKB::Serializers::WitnessArgsSerializer.from(witness).serialize)
                         else
                           Utils.hex_to_bin(witness)
-          end
+                        end
           data_size = data_binary.bytesize
 
           blake2b.update([data_size].pack("Q<"))

--- a/lib/ckb/types/tx_pool_ids.rb
+++ b/lib/ckb/types/tx_pool_ids.rb
@@ -1,0 +1,30 @@
+module CKB
+  module Types
+    class TxPoolIds
+      attr_accessor :pending, :proposed
+
+      # @param pending [String]
+      # @param proposed [String]
+      def initialize(pending:, proposed:)
+        @pending = pending
+        @proposed = proposed
+      end
+
+      def to_h
+        {
+          pending: pending,
+          proposed: proposed
+        }
+      end
+
+      def self.from_h(hash)
+        return if hash.nil?
+
+        new(
+          pending: hash[:pending],
+          proposed: hash[:proposed]
+        )
+      end
+    end
+  end
+end

--- a/lib/ckb/types/tx_pool_ids.rb
+++ b/lib/ckb/types/tx_pool_ids.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CKB
   module Types
     class TxPoolIds

--- a/lib/ckb/types/tx_pool_verbosity.rb
+++ b/lib/ckb/types/tx_pool_verbosity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CKB
   module Types
     class TxPoolVerbosity
@@ -12,8 +14,8 @@ module CKB
 
       def to_h
         {
-          pending: pending,
-          proposed: proposed
+          pending: pending.transform_values { |v| v.to_h }.to_h,
+          proposed: proposed.transform_values { |v| v.to_h }.to_h
         }
       end
 
@@ -21,8 +23,8 @@ module CKB
         return if hash.nil?
 
         new(
-          pending: hash[:pending].map { |k, v| [k, TxVerbosity.from_h(v)] }.to_h,
-          proposed: hash[:proposed].map { |k, v| [k, TxVerbosity.from_h(v)] }.to_h
+          pending: hash[:pending].transform_values { |v| TxVerbosity.from_h(v) }.to_h,
+          proposed: hash[:proposed].transform_values { |v| TxVerbosity.from_h(v) }.to_h
         )
       end
     end

--- a/lib/ckb/types/tx_pool_verbosity.rb
+++ b/lib/ckb/types/tx_pool_verbosity.rb
@@ -1,0 +1,30 @@
+module CKB
+  module Types
+    class TxPoolVerbosity
+      attr_accessor :pending, :proposed
+
+      # @param pending [Hash]
+      # @param proposed [Hash]
+      def initialize(pending:, proposed:)
+        @pending = pending
+        @proposed = proposed
+      end
+
+      def to_h
+        {
+          pending: pending,
+          proposed: proposed
+        }
+      end
+
+      def self.from_h(hash)
+        return if hash.nil?
+
+        new(
+          pending: hash[:pending].map { |k, v| [k, TxVerbosity.from_h(v)] }.to_h,
+          proposed: hash[:proposed].map { |k, v| [k, TxVerbosity.from_h(v)] }.to_h
+        )
+      end
+    end
+  end
+end

--- a/lib/ckb/types/tx_verbosity.rb
+++ b/lib/ckb/types/tx_verbosity.rb
@@ -1,0 +1,47 @@
+module CKB
+  module Types
+    class TxVerbosity
+      attr_accessor :cycles, :size, :fee, :ancestors_size, :ancestors_cycles, :ancestors_count
+
+      # @param cycles  [String | Integer]
+      # @param size [String | Integer]
+      # @param fee [String | Integer]
+      # @param ancestors_size [String | Integer]
+      # @param ancestors_cycles [String | Integer]
+      # @param ancestors_count [String | Integer]
+      # @param
+      def initialize(cycles:, size:, fee:, ancestors_size:, ancestors_cycles:, ancestors_count:)
+        @cycles = Utils.to_int(cycles)
+        @size = Utils.to_int(size)
+        @fee = Utils.to_int(fee)
+        @ancestors_size = Utils.to_int(ancestors_size)
+        @ancestors_cycles = Utils.to_int(ancestors_cycles)
+        @ancestors_count = Utils.to_int(ancestors_count)
+      end
+
+      def to_h
+        {
+          cycles: Utils.to_hex(cycles),
+          size: Utils.to_hex(size),
+          fee: Utils.to_hex(fee),
+          ancestors_size: Utils.to_hex(ancestors_size),
+          ancestors_cycles: Utils.to_hex(ancestors_cycles),
+          ancestors_count: Utils.to_hex(ancestors_count)
+        }
+      end
+
+      def self.from_h(hash)
+        return if hash.nil?
+
+        new(
+          cycles: hash[:cycles],
+          size: hash[:size],
+          fee: hash[:fee],
+          ancestors_size: hash[:ancestors_size],
+          ancestors_cycles: hash[:ancestors_cycles],
+          ancestors_count: hash[:ancestors_count]
+        )
+      end
+    end
+  end
+end

--- a/lib/ckb/types/tx_verbosity.rb
+++ b/lib/ckb/types/tx_verbosity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CKB
   module Types
     class TxVerbosity

--- a/lib/ckb/types/types.rb
+++ b/lib/ckb/types/types.rb
@@ -48,6 +48,9 @@ require_relative "merkle_proof"
 require_relative "tx_pool_ids"
 require_relative "tx_pool_verbosity"
 require_relative "tx_verbosity"
+require_relative "consensus"
+require_relative "rational_u256"
+require_relative "proposal_window"
 
 module CKB
   module Types

--- a/lib/ckb/types/types.rb
+++ b/lib/ckb/types/types.rb
@@ -45,6 +45,9 @@ require_relative "local_node"
 require_relative "local_node_protocol"
 require_relative "transaction_proof"
 require_relative "merkle_proof"
+require_relative "tx_pool_ids"
+require_relative "tx_pool_verbosity"
+require_relative "tx_verbosity"
 
 module CKB
   module Types

--- a/lib/ckb/version.rb
+++ b/lib/ckb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CKB
-  VERSION = "0.38.1"
+  VERSION = "0.39.0"
 end

--- a/spec/ckb/api_spec.rb
+++ b/spec/ckb/api_spec.rb
@@ -193,6 +193,11 @@ RSpec.describe CKB::API do
     expect(result).to be_a(Types::TxPoolIds)
   end
 
+  it "get consensus" do
+    result = api.get_consensus
+    expect(result).to be_a(Types::Consensus)
+  end
+
   it "tx pool info" do
     result = api.tx_pool_info
     expect(result).not_to be nil

--- a/spec/ckb/api_spec.rb
+++ b/spec/ckb/api_spec.rb
@@ -183,12 +183,23 @@ RSpec.describe CKB::API do
     expect(result).to be_a(Types::LocalNode)
   end
 
+  it "get verbose raw_tx_pool info" do
+    result = api.get_raw_tx_pool(true)
+    expect(result).to be_a(Types::TxPoolVerbosity)
+  end
+
+  it "get raw_tx_pool info" do
+    result = api.get_raw_tx_pool
+    expect(result).to be_a(Types::TxPoolIds)
+  end
+
   it "tx pool info" do
     result = api.tx_pool_info
     expect(result).not_to be nil
     expect(result.to_h.keys.sort).to eq %i[pending proposed orphan last_txs_updated_at min_fee_rate total_tx_cycles total_tx_size tip_hash tip_number].sort
   end
 
+  # need to clear the tx pool first
   it "clear tx pool" do
     wallet = CKB::Wallet.from_hex(api, "0xd00c06bfd800d27397002dca6fb0993d5ba6399b4238b2f29ee9deb97593d2bc", indexer_api: CKB::Indexer::API.new("http://localhost:8116"))
     wallet.send_capacity("ckt1qyqqg2rcmvgwq9ypycgqgmp5ghs3vcj8vm0s2ppgld", 1000 * 10**8, fee: 1100)

--- a/spec/ckb/types/consensus.rb
+++ b/spec/ckb/types/consensus.rb
@@ -1,61 +1,61 @@
 RSpec.describe CKB::Types::Consensus do
-	let(:consensus_h) do
-		{
-			:block_version=>"0x0",
-			:cellbase_maturity=>"0x10000000000",
-		  :dao_type_hash=>"0x82d76d1b75fe2fd9a27dfbaa65a039221a380d76c926f378d3f81cf3e7e13f2e",
-		  :epoch_duration_target=>"0x3840",
-		  :genesis_hash=>"0x823b2ff5785b12da8b1363cac9a5cbe566d8b715a4311441b119c39a0367488c",
-		  :id=>"ckb_dev",
-		  :initial_primary_epoch_reward=>"0xae6c73c3e070",
-		  :max_block_bytes=>"0x91c08",
-		  :max_block_cycles=>"0x2540be400",
-		  :max_block_proposals_limit=>"0x5dc",
-		  :max_uncles_num=>"0x2",
-		  :median_time_block_count=>"0x25",
-		  :orphan_rate_target=>{:denom=>"0x28", :numer=>"0x1"},
-		  :permanent_difficulty_in_dummy=>false,
-		  :primary_epoch_reward_halving_interval=>"0x2238",
-		  :proposer_reward_ratio=>{:denom=>"0xa", :numer=>"0x4"},
-		  :secondary_epoch_reward=>"0x37d0c8e28542",
-		  :secp256k1_blake160_multisig_all_type_hash=>"0x5c5069eb0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8",
-		  :secp256k1_blake160_sighash_all_type_hash=>"0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
-		  :tx_proposal_window=>{:closest=>"0x2", :farthest=>"0xa"},
-		  :tx_version=>"0x0",
-		  :type_id_code_hash=>"0x00000000000000000000000000000000000000000000000000545950455f4944"
-		}
-	end
+  let(:consensus_h) do
+    {
+      :block_version=>"0x0",
+      :cellbase_maturity=>"0x10000000000",
+      :dao_type_hash=>"0x82d76d1b75fe2fd9a27dfbaa65a039221a380d76c926f378d3f81cf3e7e13f2e",
+      :epoch_duration_target=>"0x3840",
+      :genesis_hash=>"0x823b2ff5785b12da8b1363cac9a5cbe566d8b715a4311441b119c39a0367488c",
+      :id=>"ckb_dev",
+      :initial_primary_epoch_reward=>"0xae6c73c3e070",
+      :max_block_bytes=>"0x91c08",
+      :max_block_cycles=>"0x2540be400",
+      :max_block_proposals_limit=>"0x5dc",
+      :max_uncles_num=>"0x2",
+      :median_time_block_count=>"0x25",
+      :orphan_rate_target=>{:denom=>"0x28", :numer=>"0x1"},
+      :permanent_difficulty_in_dummy=>false,
+      :primary_epoch_reward_halving_interval=>"0x2238",
+      :proposer_reward_ratio=>{:denom=>"0xa", :numer=>"0x4"},
+      :secondary_epoch_reward=>"0x37d0c8e28542",
+      :secp256k1_blake160_multisig_all_type_hash=>"0x5c5069eb0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8",
+      :secp256k1_blake160_sighash_all_type_hash=>"0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+      :tx_proposal_window=>{:closest=>"0x2", :farthest=>"0xa"},
+      :tx_version=>"0x0",
+      :type_id_code_hash=>"0x00000000000000000000000000000000000000000000000000545950455f4944"
+    }
+  end
 
-	let(:consensus) { CKB::Types::Consensus.from_h(consensus_h) }
+  let(:consensus) { CKB::Types::Consensus.from_h(consensus_h) }
 
-	it "from h" do
-		expect(consensus).to be_a(CKB::Types::Consensus)
-		expect(consensus.id).to eq consensus_h[:id]
-		expect(consensus.genesis_hash).to eq consensus_h[:genesis_hash]
-		expect(consensus.dao_type_hash).to eq consensus_h[:dao_type_hash]
-		expect(consensus.secp256k1_blake160_sighash_all_type_hash).to eq consensus_h[:secp256k1_blake160_sighash_all_type_hash]
-		expect(consensus.secp256k1_blake160_multisig_all_type_hash).to eq consensus_h[:secp256k1_blake160_multisig_all_type_hash]
-		expect(CKB::Utils.to_hex(consensus.initial_primary_epoch_reward)).to eq consensus_h[:initial_primary_epoch_reward]
-		expect(CKB::Utils.to_hex(consensus.secondary_epoch_reward)).to eq consensus_h[:secondary_epoch_reward]
-		expect(CKB::Utils.to_hex(consensus.max_uncles_num)).to eq consensus_h[:max_uncles_num]
-		expect(consensus.orphan_rate_target.to_h).to eq consensus_h[:orphan_rate_target]
-		expect(CKB::Utils.to_hex(consensus.epoch_duration_target)).to eq consensus_h[:epoch_duration_target]
-		expect(consensus.tx_proposal_window.to_h).to eq consensus_h[:tx_proposal_window]
-		expect(consensus.proposer_reward_ratio.to_h).to eq consensus_h[:proposer_reward_ratio]
-		expect(consensus.cellbase_maturity).to eq consensus_h[:cellbase_maturity]
-		expect(CKB::Utils.to_hex(consensus.max_block_cycles)).to eq consensus_h[:max_block_cycles]
-		expect(CKB::Utils.to_hex(consensus.max_block_bytes)).to eq consensus_h[:max_block_bytes]
-		expect(CKB::Utils.to_hex(consensus.block_version)).to eq consensus_h[:block_version]
-		expect(CKB::Utils.to_hex(consensus.tx_version)).to eq consensus_h[:tx_version]
-		expect(consensus.type_id_code_hash).to eq consensus_h[:type_id_code_hash]
-		expect(CKB::Utils.to_hex(consensus.max_block_proposals_limit)).to eq consensus_h[:max_block_proposals_limit]
-		expect(CKB::Utils.to_hex(consensus.primary_epoch_reward_halving_interval)).to eq consensus_h[:primary_epoch_reward_halving_interval]
-		expect(consensus.permanent_difficulty_in_dummy).to eq consensus_h[:permanent_difficulty_in_dummy]
-	end
+  it "from h" do
+    expect(consensus).to be_a(CKB::Types::Consensus)
+    expect(consensus.id).to eq consensus_h[:id]
+    expect(consensus.genesis_hash).to eq consensus_h[:genesis_hash]
+    expect(consensus.dao_type_hash).to eq consensus_h[:dao_type_hash]
+    expect(consensus.secp256k1_blake160_sighash_all_type_hash).to eq consensus_h[:secp256k1_blake160_sighash_all_type_hash]
+    expect(consensus.secp256k1_blake160_multisig_all_type_hash).to eq consensus_h[:secp256k1_blake160_multisig_all_type_hash]
+    expect(CKB::Utils.to_hex(consensus.initial_primary_epoch_reward)).to eq consensus_h[:initial_primary_epoch_reward]
+    expect(CKB::Utils.to_hex(consensus.secondary_epoch_reward)).to eq consensus_h[:secondary_epoch_reward]
+    expect(CKB::Utils.to_hex(consensus.max_uncles_num)).to eq consensus_h[:max_uncles_num]
+    expect(consensus.orphan_rate_target.to_h).to eq consensus_h[:orphan_rate_target]
+    expect(CKB::Utils.to_hex(consensus.epoch_duration_target)).to eq consensus_h[:epoch_duration_target]
+    expect(consensus.tx_proposal_window.to_h).to eq consensus_h[:tx_proposal_window]
+    expect(consensus.proposer_reward_ratio.to_h).to eq consensus_h[:proposer_reward_ratio]
+    expect(consensus.cellbase_maturity).to eq consensus_h[:cellbase_maturity]
+    expect(CKB::Utils.to_hex(consensus.max_block_cycles)).to eq consensus_h[:max_block_cycles]
+    expect(CKB::Utils.to_hex(consensus.max_block_bytes)).to eq consensus_h[:max_block_bytes]
+    expect(CKB::Utils.to_hex(consensus.block_version)).to eq consensus_h[:block_version]
+    expect(CKB::Utils.to_hex(consensus.tx_version)).to eq consensus_h[:tx_version]
+    expect(consensus.type_id_code_hash).to eq consensus_h[:type_id_code_hash]
+    expect(CKB::Utils.to_hex(consensus.max_block_proposals_limit)).to eq consensus_h[:max_block_proposals_limit]
+    expect(CKB::Utils.to_hex(consensus.primary_epoch_reward_halving_interval)).to eq consensus_h[:primary_epoch_reward_halving_interval]
+    expect(consensus.permanent_difficulty_in_dummy).to eq consensus_h[:permanent_difficulty_in_dummy]
+  end
 
-	it "to_h" do
-		expect(
-			consensus.to_h
-		).to eq consensus_h
-	end
+  it "to_h" do
+    expect(
+      consensus.to_h
+    ).to eq consensus_h
+  end
 end

--- a/spec/ckb/types/consensus.rb
+++ b/spec/ckb/types/consensus.rb
@@ -1,0 +1,61 @@
+RSpec.describe CKB::Types::Consensus do
+	let(:consensus_h) do
+		{
+			:block_version=>"0x0",
+			:cellbase_maturity=>"0x10000000000",
+		  :dao_type_hash=>"0x82d76d1b75fe2fd9a27dfbaa65a039221a380d76c926f378d3f81cf3e7e13f2e",
+		  :epoch_duration_target=>"0x3840",
+		  :genesis_hash=>"0x823b2ff5785b12da8b1363cac9a5cbe566d8b715a4311441b119c39a0367488c",
+		  :id=>"ckb_dev",
+		  :initial_primary_epoch_reward=>"0xae6c73c3e070",
+		  :max_block_bytes=>"0x91c08",
+		  :max_block_cycles=>"0x2540be400",
+		  :max_block_proposals_limit=>"0x5dc",
+		  :max_uncles_num=>"0x2",
+		  :median_time_block_count=>"0x25",
+		  :orphan_rate_target=>{:denom=>"0x28", :numer=>"0x1"},
+		  :permanent_difficulty_in_dummy=>false,
+		  :primary_epoch_reward_halving_interval=>"0x2238",
+		  :proposer_reward_ratio=>{:denom=>"0xa", :numer=>"0x4"},
+		  :secondary_epoch_reward=>"0x37d0c8e28542",
+		  :secp256k1_blake160_multisig_all_type_hash=>"0x5c5069eb0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8",
+		  :secp256k1_blake160_sighash_all_type_hash=>"0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+		  :tx_proposal_window=>{:closest=>"0x2", :farthest=>"0xa"},
+		  :tx_version=>"0x0",
+		  :type_id_code_hash=>"0x00000000000000000000000000000000000000000000000000545950455f4944"
+		}
+	end
+
+	let(:consensus) { CKB::Types::Consensus.from_h(consensus_h) }
+
+	it "from h" do
+		expect(consensus).to be_a(CKB::Types::Consensus)
+		expect(consensus.id).to eq consensus_h[:id]
+		expect(consensus.genesis_hash).to eq consensus_h[:genesis_hash]
+		expect(consensus.dao_type_hash).to eq consensus_h[:dao_type_hash]
+		expect(consensus.secp256k1_blake160_sighash_all_type_hash).to eq consensus_h[:secp256k1_blake160_sighash_all_type_hash]
+		expect(consensus.secp256k1_blake160_multisig_all_type_hash).to eq consensus_h[:secp256k1_blake160_multisig_all_type_hash]
+		expect(CKB::Utils.to_hex(consensus.initial_primary_epoch_reward)).to eq consensus_h[:initial_primary_epoch_reward]
+		expect(CKB::Utils.to_hex(consensus.secondary_epoch_reward)).to eq consensus_h[:secondary_epoch_reward]
+		expect(CKB::Utils.to_hex(consensus.max_uncles_num)).to eq consensus_h[:max_uncles_num]
+		expect(consensus.orphan_rate_target.to_h).to eq consensus_h[:orphan_rate_target]
+		expect(CKB::Utils.to_hex(consensus.epoch_duration_target)).to eq consensus_h[:epoch_duration_target]
+		expect(consensus.tx_proposal_window.to_h).to eq consensus_h[:tx_proposal_window]
+		expect(consensus.proposer_reward_ratio.to_h).to eq consensus_h[:proposer_reward_ratio]
+		expect(consensus.cellbase_maturity).to eq consensus_h[:cellbase_maturity]
+		expect(CKB::Utils.to_hex(consensus.max_block_cycles)).to eq consensus_h[:max_block_cycles]
+		expect(CKB::Utils.to_hex(consensus.max_block_bytes)).to eq consensus_h[:max_block_bytes]
+		expect(CKB::Utils.to_hex(consensus.block_version)).to eq consensus_h[:block_version]
+		expect(CKB::Utils.to_hex(consensus.tx_version)).to eq consensus_h[:tx_version]
+		expect(consensus.type_id_code_hash).to eq consensus_h[:type_id_code_hash]
+		expect(CKB::Utils.to_hex(consensus.max_block_proposals_limit)).to eq consensus_h[:max_block_proposals_limit]
+		expect(CKB::Utils.to_hex(consensus.primary_epoch_reward_halving_interval)).to eq consensus_h[:primary_epoch_reward_halving_interval]
+		expect(consensus.permanent_difficulty_in_dummy).to eq consensus_h[:permanent_difficulty_in_dummy]
+	end
+
+	it "to_h" do
+		expect(
+			consensus.to_h
+		).to eq consensus_h
+	end
+end

--- a/spec/ckb/types/proposal_window_spec.rb
+++ b/spec/ckb/types/proposal_window_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe CKB::Types::ProposalWindow do
+	let(:proposal_window_h) do
+		{
+			:closest=>"0x2",
+			:farthest=>"0xa"
+		}
+	end
+
+	let(:proposal_window) { CKB::Types::ProposalWindow.from_h(proposal_window_h) }
+
+	it "from h" do
+		expect(proposal_window).to be_a(CKB::Types::ProposalWindow)
+		proposal_window_h.each do |key, value|
+			expect(proposal_window.public_send(key)).to eq value.hex
+		end
+	end
+
+	it "to_h" do
+		expect(
+			proposal_window.to_h
+		).to eq proposal_window_h
+	end
+end

--- a/spec/ckb/types/proposal_window_spec.rb
+++ b/spec/ckb/types/proposal_window_spec.rb
@@ -1,23 +1,23 @@
 RSpec.describe CKB::Types::ProposalWindow do
-	let(:proposal_window_h) do
-		{
-			:closest=>"0x2",
-			:farthest=>"0xa"
-		}
-	end
+  let(:proposal_window_h) do
+    {
+      closest: "0x2",
+      farthest: "0xa"
+    }
+  end
 
-	let(:proposal_window) { CKB::Types::ProposalWindow.from_h(proposal_window_h) }
+  let(:proposal_window) { CKB::Types::ProposalWindow.from_h(proposal_window_h) }
 
-	it "from h" do
-		expect(proposal_window).to be_a(CKB::Types::ProposalWindow)
-		proposal_window_h.each do |key, value|
-			expect(proposal_window.public_send(key)).to eq value.hex
-		end
-	end
+  it "from h" do
+    expect(proposal_window).to be_a(CKB::Types::ProposalWindow)
+    proposal_window_h.each do |key, value|
+      expect(proposal_window.public_send(key)).to eq value.hex
+    end
+  end
 
-	it "to_h" do
-		expect(
-			proposal_window.to_h
-		).to eq proposal_window_h
-	end
+  it "to_h" do
+    expect(
+      proposal_window.to_h
+    ).to eq proposal_window_h
+  end
 end

--- a/spec/ckb/types/rational_u256_spec.rb
+++ b/spec/ckb/types/rational_u256_spec.rb
@@ -1,23 +1,23 @@
 RSpec.describe CKB::Types::RationalU256 do
-	let(:rationalu256_h) do
-		{
-			:denom=>"0x28",
-			:numer=>"0x1"
-		}
-	end
+  let(:rationalu256_h) do
+    {
+      denom: "0x28",
+      numer: "0x1"
+    }
+  end
 
-	let(:rationalu256) { CKB::Types::RationalU256.from_h(rationalu256_h) }
+  let(:rationalu256) { CKB::Types::RationalU256.from_h(rationalu256_h) }
 
-	it "from h" do
-		expect(rationalu256).to be_a(CKB::Types::RationalU256)
-		rationalu256_h.each do |key, value|
-			expect(rationalu256.public_send(key)).to eq value
-		end
-	end
+  it "from h" do
+    expect(rationalu256).to be_a(CKB::Types::RationalU256)
+    rationalu256_h.each do |key, value|
+      expect(rationalu256.public_send(key)).to eq value
+    end
+  end
 
-	it "to_h" do
-		expect(
-			rationalu256.to_h
-		).to eq rationalu256_h
-	end
+  it "to_h" do
+    expect(
+      rationalu256.to_h
+    ).to eq rationalu256_h
+  end
 end

--- a/spec/ckb/types/rational_u256_spec.rb
+++ b/spec/ckb/types/rational_u256_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe CKB::Types::RationalU256 do
+	let(:rationalu256_h) do
+		{
+			:denom=>"0x28",
+			:numer=>"0x1"
+		}
+	end
+
+	let(:rationalu256) { CKB::Types::RationalU256.from_h(rationalu256_h) }
+
+	it "from h" do
+		expect(rationalu256).to be_a(CKB::Types::RationalU256)
+		rationalu256_h.each do |key, value|
+			expect(rationalu256.public_send(key)).to eq value
+		end
+	end
+
+	it "to_h" do
+		expect(
+			rationalu256.to_h
+		).to eq rationalu256_h
+	end
+end

--- a/spec/ckb/types/tx_pool_ids_spec.rb
+++ b/spec/ckb/types/tx_pool_ids_spec.rb
@@ -1,23 +1,23 @@
 RSpec.describe CKB::Types::TxPoolIds do
-	let(:tx_pool_ids_h) do
-		{
-			"pending": %w[0xa0ef4eb5f4ceeb08a4c8524d84c5da95dce2f608e0ca2ec8091191b0f330c6e3 0x0a365f660592e22ba0aaad94fc4bda8d8522c3f33c473fc65c14645deab4c0bf 0x0a365f660592e22ba0aaad94fc4bda8d8522c3f33c473fc65c14645deab4c0bf],
-			"proposed": %w[0x19f8058273c5ed4b341f48503b49a97a76dc815f081b8b57309f9cf20b5139ae 0x6f14e3a5029c62c04c4447e736d7c9fb4907b0e479e9f163ca95baaad158fcc6],
-		}
-	end
+  let(:tx_pool_ids_h) do
+    {
+      "pending": %w[0xa0ef4eb5f4ceeb08a4c8524d84c5da95dce2f608e0ca2ec8091191b0f330c6e3 0x0a365f660592e22ba0aaad94fc4bda8d8522c3f33c473fc65c14645deab4c0bf 0x0a365f660592e22ba0aaad94fc4bda8d8522c3f33c473fc65c14645deab4c0bf],
+      "proposed": %w[0x19f8058273c5ed4b341f48503b49a97a76dc815f081b8b57309f9cf20b5139ae 0x6f14e3a5029c62c04c4447e736d7c9fb4907b0e479e9f163ca95baaad158fcc6]
+    }
+  end
 
-	let(:tx_pool_ids) { CKB::Types::TxPoolIds.from_h(tx_pool_ids_h) }
+  let(:tx_pool_ids) { CKB::Types::TxPoolIds.from_h(tx_pool_ids_h) }
 
-	it "from h" do
-		expect(tx_pool_ids).to be_a(CKB::Types::TxPoolIds)
-		tx_pool_ids_h.each do |key, value|
-			expect(tx_pool_ids.public_send(key)).to eq value
-		end
-	end
+  it "from h" do
+    expect(tx_pool_ids).to be_a(CKB::Types::TxPoolIds)
+    tx_pool_ids_h.each do |key, value|
+      expect(tx_pool_ids.public_send(key)).to eq value
+    end
+  end
 
-	it "to_h" do
-		expect(
-			tx_pool_ids.to_h
-		).to eq tx_pool_ids_h
-	end
+  it "to_h" do
+    expect(
+      tx_pool_ids.to_h
+    ).to eq tx_pool_ids_h
+  end
 end

--- a/spec/ckb/types/tx_pool_ids_spec.rb
+++ b/spec/ckb/types/tx_pool_ids_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe CKB::Types::TxPoolIds do
+	let(:tx_pool_ids_h) do
+		{
+			"pending": %w[0xa0ef4eb5f4ceeb08a4c8524d84c5da95dce2f608e0ca2ec8091191b0f330c6e3 0x0a365f660592e22ba0aaad94fc4bda8d8522c3f33c473fc65c14645deab4c0bf 0x0a365f660592e22ba0aaad94fc4bda8d8522c3f33c473fc65c14645deab4c0bf],
+			"proposed": %w[0x19f8058273c5ed4b341f48503b49a97a76dc815f081b8b57309f9cf20b5139ae 0x6f14e3a5029c62c04c4447e736d7c9fb4907b0e479e9f163ca95baaad158fcc6],
+		}
+	end
+
+	let(:tx_pool_ids) { CKB::Types::TxPoolIds.from_h(tx_pool_ids_h) }
+
+	it "from h" do
+		expect(tx_pool_ids).to be_a(CKB::Types::TxPoolIds)
+		tx_pool_ids_h.each do |key, value|
+			expect(tx_pool_ids.public_send(key)).to eq value
+		end
+	end
+
+	it "to_h" do
+		expect(
+			tx_pool_ids.to_h
+		).to eq tx_pool_ids_h
+	end
+end

--- a/spec/ckb/types/tx_pool_verbosity_spec.rb
+++ b/spec/ckb/types/tx_pool_verbosity_spec.rb
@@ -1,29 +1,29 @@
 RSpec.describe CKB::Types::TxPoolVerbosity do
-	let(:tx_pool_verbosity_h) do
-		{
-			:pending => {
-				:"0xb9dfce5eacd8b9d5dadb20172d81795d05926f2bbf5774db40eabf0039a31803" => {:cycles => "0x19bab7", :size => "0x1d0", :fee => "0x258", :ancestors_size => "0x1d0", :ancestors_cycles => "0x19bab7", :ancestors_count => "0x1"},
-				:"0x0a365f660592e22ba0aaad94fc4bda8d8522c3f33c473fc65c14645deab4c0bf" => {:cycles => "0x19bab7", :size => "0x1d0", :fee => "0x258", :ancestors_size => "0x1d0", :ancestors_cycles => "0x19bab7", :ancestors_count => "0x1"}
-			},
-			:proposed => {
-				:"0x0a365f660592e22ba0aaad94fc4bda8d8522c3f33c473fc65c14645deab4c0bf" => {:cycles => "0x19bab7", :size => "0x1d0", :fee => "0x258", :ancestors_size => "0x1d0", :ancestors_cycles => "0x19bab7", :ancestors_count => "0x1"},
-				:"0x6f14e3a5029c62c04c4447e736d7c9fb4907b0e479e9f163ca95baaad158fcc6" => {:cycles => "0x19bab7", :size => "0x1d0", :fee => "0x258", :ancestors_size => "0x1d0", :ancestors_cycles => "0x19bab7", :ancestors_count => "0x1"}
-			},
-		}
-	end
+  let(:tx_pool_verbosity_h) do
+    {
+      :pending => {
+        :"0xb9dfce5eacd8b9d5dadb20172d81795d05926f2bbf5774db40eabf0039a31803" => {:cycles => "0x19bab7", :size => "0x1d0", :fee => "0x258", :ancestors_size => "0x1d0", :ancestors_cycles => "0x19bab7", :ancestors_count => "0x1"},
+        :"0x0a365f660592e22ba0aaad94fc4bda8d8522c3f33c473fc65c14645deab4c0bf" => {:cycles => "0x19bab7", :size => "0x1d0", :fee => "0x258", :ancestors_size => "0x1d0", :ancestors_cycles => "0x19bab7", :ancestors_count => "0x1"}
+      },
+      :proposed => {
+        :"0x0a365f660592e22ba0aaad94fc4bda8d8522c3f33c473fc65c14645deab4c0bf" => {:cycles => "0x19bab7", :size => "0x1d0", :fee => "0x258", :ancestors_size => "0x1d0", :ancestors_cycles => "0x19bab7", :ancestors_count => "0x1"},
+        :"0x6f14e3a5029c62c04c4447e736d7c9fb4907b0e479e9f163ca95baaad158fcc6" => {:cycles => "0x19bab7", :size => "0x1d0", :fee => "0x258", :ancestors_size => "0x1d0", :ancestors_cycles => "0x19bab7", :ancestors_count => "0x1"}
+      },
+    }
+  end
 
-	let(:tx_pool_verbosity) { CKB::Types::TxPoolVerbosity.from_h(tx_pool_verbosity_h) }
+  let(:tx_pool_verbosity) { CKB::Types::TxPoolVerbosity.from_h(tx_pool_verbosity_h) }
 
-	it "from h" do
-		expect(tx_pool_verbosity).to be_a(CKB::Types::TxPoolVerbosity)
-		tx_pool_verbosity_h.each do |key, value|
-			expect(tx_pool_verbosity.public_send(key).transform_values { |v| v.to_h }.to_h).to eq value
-		end
-	end
+  it "from h" do
+    expect(tx_pool_verbosity).to be_a(CKB::Types::TxPoolVerbosity)
+    tx_pool_verbosity_h.each do |key, value|
+      expect(tx_pool_verbosity.public_send(key).transform_values { |v| v.to_h }.to_h).to eq value
+    end
+  end
 
-	it "to_h" do
-		expect(
-			tx_pool_verbosity.to_h
-		).to eq tx_pool_verbosity_h
-	end
+  it "to_h" do
+    expect(
+      tx_pool_verbosity.to_h
+    ).to eq tx_pool_verbosity_h
+  end
 end

--- a/spec/ckb/types/tx_pool_verbosity_spec.rb
+++ b/spec/ckb/types/tx_pool_verbosity_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CKB::Types::TxPoolVerbosity do
 	it "from h" do
 		expect(tx_pool_verbosity).to be_a(CKB::Types::TxPoolVerbosity)
 		tx_pool_verbosity_h.each do |key, value|
-			expect(tx_pool_verbosity.public_send(key).map { |k, v| [k, v.to_h] }.to_h).to eq value
+			expect(tx_pool_verbosity.public_send(key).transform_values { |v| v.to_h }.to_h).to eq value
 		end
 	end
 

--- a/spec/ckb/types/tx_pool_verbosity_spec.rb
+++ b/spec/ckb/types/tx_pool_verbosity_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe CKB::Types::TxPoolVerbosity do
+	let(:tx_pool_verbosity_h) do
+		{
+			:pending => {
+				:"0xb9dfce5eacd8b9d5dadb20172d81795d05926f2bbf5774db40eabf0039a31803" => {:cycles => "0x19bab7", :size => "0x1d0", :fee => "0x258", :ancestors_size => "0x1d0", :ancestors_cycles => "0x19bab7", :ancestors_count => "0x1"},
+				:"0x0a365f660592e22ba0aaad94fc4bda8d8522c3f33c473fc65c14645deab4c0bf" => {:cycles => "0x19bab7", :size => "0x1d0", :fee => "0x258", :ancestors_size => "0x1d0", :ancestors_cycles => "0x19bab7", :ancestors_count => "0x1"}
+			},
+			:proposed => {
+				:"0x0a365f660592e22ba0aaad94fc4bda8d8522c3f33c473fc65c14645deab4c0bf" => {:cycles => "0x19bab7", :size => "0x1d0", :fee => "0x258", :ancestors_size => "0x1d0", :ancestors_cycles => "0x19bab7", :ancestors_count => "0x1"},
+				:"0x6f14e3a5029c62c04c4447e736d7c9fb4907b0e479e9f163ca95baaad158fcc6" => {:cycles => "0x19bab7", :size => "0x1d0", :fee => "0x258", :ancestors_size => "0x1d0", :ancestors_cycles => "0x19bab7", :ancestors_count => "0x1"}
+			},
+		}
+	end
+
+	let(:tx_pool_verbosity) { CKB::Types::TxPoolVerbosity.from_h(tx_pool_verbosity_h) }
+
+	it "from h" do
+		expect(tx_pool_verbosity).to be_a(CKB::Types::TxPoolVerbosity)
+		tx_pool_verbosity_h.each do |key, value|
+			expect(tx_pool_verbosity.public_send(key).map { |k, v| [k, v.to_h] }.to_h).to eq value
+		end
+	end
+
+	it "to_h" do
+		expect(
+			tx_pool_verbosity.to_h
+		).to eq tx_pool_verbosity_h
+	end
+end

--- a/spec/ckb/types/tx_verbosity_spec.rb
+++ b/spec/ckb/types/tx_verbosity_spec.rb
@@ -1,20 +1,20 @@
 RSpec.describe CKB::Types::TxVerbosity do
-	let(:tx_verbosity_h) do
-		{:cycles => "0x19bab7", :size => "0x1d0", :fee => "0x258", :ancestors_size => "0x1d0", :ancestors_cycles => "0x19bab7", :ancestors_count => "0x1"}
-	end
+  let(:tx_verbosity_h) do
+    {:cycles => "0x19bab7", :size => "0x1d0", :fee => "0x258", :ancestors_size => "0x1d0", :ancestors_cycles => "0x19bab7", :ancestors_count => "0x1"}
+  end
 
-	let(:tx_verbosity) { CKB::Types::TxVerbosity.from_h(tx_verbosity_h) }
+  let(:tx_verbosity) { CKB::Types::TxVerbosity.from_h(tx_verbosity_h) }
 
-	it "from h" do
-		expect(tx_verbosity).to be_a(CKB::Types::TxVerbosity)
-		tx_verbosity_h.each do |key, value|
-			expect(tx_verbosity.public_send(key)).to eq CKB::Utils.to_int(value)
-		end
-	end
+  it "from h" do
+    expect(tx_verbosity).to be_a(CKB::Types::TxVerbosity)
+    tx_verbosity_h.each do |key, value|
+      expect(tx_verbosity.public_send(key)).to eq CKB::Utils.to_int(value)
+    end
+  end
 
-	it "to_h" do
-		expect(
-			tx_verbosity.to_h
-		).to eq tx_verbosity_h
-	end
+  it "to_h" do
+    expect(
+      tx_verbosity.to_h
+    ).to eq tx_verbosity_h
+  end
 end

--- a/spec/ckb/types/tx_verbosity_spec.rb
+++ b/spec/ckb/types/tx_verbosity_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe CKB::Types::TxVerbosity do
+	let(:tx_verbosity_h) do
+		{:cycles => "0x19bab7", :size => "0x1d0", :fee => "0x258", :ancestors_size => "0x1d0", :ancestors_cycles => "0x19bab7", :ancestors_count => "0x1"}
+	end
+
+	let(:tx_verbosity) { CKB::Types::TxVerbosity.from_h(tx_verbosity_h) }
+
+	it "from h" do
+		expect(tx_verbosity).to be_a(CKB::Types::TxVerbosity)
+		tx_verbosity_h.each do |key, value|
+			expect(tx_verbosity.public_send(key)).to eq CKB::Utils.to_int(value)
+		end
+	end
+
+	it "to_h" do
+		expect(
+			tx_verbosity.to_h
+		).to eq tx_verbosity_h
+	end
+end


### PR DESCRIPTION
# [v0.39.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.38.1...v0.39.0) (2021-01-12)


### Features

* add consensus related types ([d29fe4a](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/d29fe4a))
* add get_consensus RPC ([88de068](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/88de068))
* add get_raw_tx_pool RPC ([87479b5](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/87479b5))
