### PR TITLE
Rc/v0.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# [v0.40.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.39.0...v0.40.0) (2021-03-10)
+
+
+### Features
+
+* add serialized_size_without_uncle_proposals ([43f5077](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/43f5077))
+* deprecate get_cellbase_output_capacity_details and get_peers_state RPC ([2475550](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/2475550))
+
+
+### Performance Improvements
+
+* byte32 serializer ([9574a5e](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/9574a5e))
+* bytes serializer ([9193fc9](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/9193fc9))
+* output data serializer ([5c8e82e](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/5c8e82e))
+
+
+
 # [v0.39.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.38.1...v0.39.0) (2021-01-12)
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ckb-sdk-ruby (0.39.0)
+    ckb-sdk-ruby (0.40.0)
       bitcoin-secp256k1 (~> 0.5.2)
       net-http-persistent (~> 3.1.0)
       rbnacl (~> 7.1.1)
@@ -15,7 +15,7 @@ GEM
     coderay (1.1.2)
     connection_pool (2.2.3)
     diff-lcs (1.3)
-    ffi (1.14.2)
+    ffi (1.15.0)
     jaro_winkler (1.5.2)
     method_source (0.9.2)
     net-http-persistent (3.1.0)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ruby SDK for CKB
 The ckb-sdk-ruby is still under development and NOT production ready. You should get familiar with CKB transaction structure and RPC before using it.
 
 ## WARNING
-Module Indexer hash been removed from [ckb_v0.40.0](https://github.com/nervosnetwork/ckb/releases/tag/v0.40.0): Please use [ckb-indexer](https://github.com/nervosnetwork/ckb-indexer) as an alternate solution.
+Module Indexer has been removed from [ckb_v0.40.0](https://github.com/nervosnetwork/ckb/releases/tag/v0.40.0): Please use [ckb-indexer](https://github.com/nervosnetwork/ckb-indexer) as an alternate solution.
 
 The following RPCs hash been removed from [ckb_v0.40.0](https://github.com/nervosnetwork/ckb/releases/tag/v0.40.0):
 * `get_live_cells_by_lock_hash`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ Ruby SDK for CKB
 
 The ckb-sdk-ruby is still under development and NOT production ready. You should get familiar with CKB transaction structure and RPC before using it.
 
+## WARNING
+Module Indexer hash been removed from [ckb_v0.40.0](https://github.com/nervosnetwork/ckb/releases/tag/v0.40.0): Please use [ckb-indexer](https://github.com/nervosnetwork/ckb-indexer) as an alternate solution.
+
+The following RPCs hash been removed from [ckb_v0.40.0](https://github.com/nervosnetwork/ckb/releases/tag/v0.40.0):
+* `get_live_cells_by_lock_hash`
+* `get_transactions_by_lock_hash`
+* `index_lock_hash`
+* `deindex_lock_hash`
+* `get_lock_hash_index_states`
+* `get_capacity_by_lock_hash`
+
+Since [ckb_v0.36.0](https://github.com/nervosnetwork/ckb/releases/tag/v0.36.0) SDK use [ckb-indexer](https://github.com/nervosnetwork/ckb-indexer) to collect cells, please see [Usage](#usage) for examples.
+
 ## Prerequisites
 
 Require Ruby 2.4 and above.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,9 +1,14 @@
-# [v0.39.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.38.1...v0.39.0) (2021-01-12)
+# [v0.40.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.39.0...v0.40.0) (2021-03-10)
 
 
 ### Features
 
-* add consensus related types ([d29fe4a](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/d29fe4a))
-* add get_consensus RPC ([88de068](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/88de068))
-* add get_raw_tx_pool RPC ([87479b5](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/87479b5))
+* add serialized_size_without_uncle_proposals ([43f5077](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/43f5077))
+* deprecate get_cellbase_output_capacity_details and get_peers_state RPC ([2475550](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/2475550))
 
+
+### Performance Improvements
+
+* byte32 serializer ([9574a5e](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/9574a5e))
+* bytes serializer ([9193fc9](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/9193fc9))
+* output data serializer ([5c8e82e](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/5c8e82e))

--- a/lib/ckb/api.rb
+++ b/lib/ckb/api.rb
@@ -145,12 +145,12 @@ module CKB
     end
 
     def _compute_transaction_hash(transaction)
-      warn "[DEPRECATION] `_compute_transaction_hash` will be removed in a later version."
+      warn "[DEPRECATION] `_compute_transaction_hash` will be disabled by default from v0.40.0 and will be removed from v0.41.0."
       rpc._compute_transaction_hash(transaction.to_raw_transaction_h)
     end
 
     def _compute_script_hash(script)
-      warn "[DEPRECATION] `_compute_script_hash` will be removed in a later version."
+      warn "[DEPRECATION] `_compute_script_hash` will be disabled by default from v0.40.0 and will be removed from v0.41.0."
       rpc._compute_script_hash(script.to_h)
     end
 
@@ -203,6 +203,7 @@ module CKB
 
     # @return [CKB::Types::PeerState[]]
     def get_peers_state
+      warn "[DEPRECATION] `get_peers_state` will be disabled by default from v0.40.0 and will be removed from v0.41.0."
       rpc.get_peers_state.map { |peer| Types::PeerState.from_h(peer) }
     end
 
@@ -242,6 +243,7 @@ module CKB
     #
     # @return [CKB::Types::BlockReward]
     def get_cellbase_output_capacity_details(block_hash)
+      warn "[DEPRECATION] `get_cellbase_output_capacity_details` will be disabled by default from v0.40.0 and will be removed from v0.41.0."
       block_reward_h = rpc.get_cellbase_output_capacity_details(block_hash)
       Types::BlockReward.from_h(block_reward_h)
     end

--- a/lib/ckb/types/block.rb
+++ b/lib/ckb/types/block.rb
@@ -16,6 +16,14 @@ module CKB
         @header = header
       end
 
+      # https://github.com/nervosnetwork/ckb/blob/develop/util/types/src/extension/serialized_size.rs#L22-L30
+      def serialized_size_without_uncle_proposals
+        block_size = CKB::Serializers::BlockSerializer.new(self).capacity
+        uncles_proposals_size = self.uncles.map { |uncle| uncle.proposals.map { |proposal| CKB::Serializers::ProposalShortIdSerializer.new(proposal).capacity - CKB::Serializers::TableSerializer::UINT32_CAPACITY }.sum }.sum
+
+        block_size - uncles_proposals_size
+      end
+
       def to_h
         {
           uncles: @uncles.map(&:to_h),

--- a/lib/ckb/version.rb
+++ b/lib/ckb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CKB
-  VERSION = "0.39.0"
+  VERSION = "0.40.0"
 end

--- a/spec/ckb/api_spec.rb
+++ b/spec/ckb/api_spec.rb
@@ -240,11 +240,6 @@ RSpec.describe CKB::API do
     expect(result.epoch >= 0).to be true
   end
 
-  it "get peers state" do
-    result = api.get_peers_state
-    expect(result).to be_an(Array)
-  end
-
   it "dry run transaction" do
     tx = Types::Transaction.new(
       version: 0,
@@ -270,13 +265,6 @@ RSpec.describe CKB::API do
     result = api.get_header_by_number(block_number)
     expect(result).to be_a(Types::BlockHeader)
     expect(result.number).to eq block_number
-  end
-
-  # need to mine more than 12 blocks locally
-  it "get block reward by block hash" do
-    block_hash = api.get_block_hash(12)
-    result = api.get_cellbase_output_capacity_details(block_hash)
-    expect(result).to be_a(Types::BlockReward)
   end
 
   it "set ban" do

--- a/spec/ckb/rpc_spec.rb
+++ b/spec/ckb/rpc_spec.rb
@@ -209,13 +209,6 @@ RSpec.describe CKB::RPC do
     expect(result[:number].hex).to eq block_number
   end
 
-  # need to mine more than 12 blocks locally
-  it "get block reward by block hash" do
-    block_hash = rpc.get_block_hash(12)
-    result = rpc.get_cellbase_output_capacity_details(block_hash)
-    expect(result).not_to be nil
-  end
-
   it "set ban" do
     params = ["192.168.0.2", "insert", 1_840_546_800_000, true, "test set_ban rpc"]
     result = rpc.set_ban(*params)

--- a/spec/ckb/types/script_spec.rb
+++ b/spec/ckb/types/script_spec.rb
@@ -13,41 +13,6 @@ RSpec.describe CKB::Types::Script do
 
   let(:code_hash) { "0xc00073200d2b2f4ad816a8d04bb2431ce0d3ebd49141b086eda4ab4e06bc3a21" }
 
-  context "to_hash" do
-    before do
-      skip if ENV["SKIP_RPC_TESTS"]
-    end
-
-    let(:api) { CKB::API.new }
-
-    it "should build correct hash when args is empty " do
-      expect(
-        script.compute_hash
-      ).to eq api._compute_script_hash(script)
-    end
-
-    it "should build correct hash when there is only one arg" do
-      script = CKB::Types::Script.new(
-        code_hash: code_hash,
-        args: "0x3954acece65096bfa81258983ddb83915fc56bd8"
-      )
-
-      expect(
-        script.compute_hash
-      ).to eq api._compute_script_hash(script)
-    end
-
-    it "should build correct hash when args more than one" do
-      script = CKB::Types::Script.new(
-        code_hash: code_hash,
-        args: "0x3954acece65096bfa81258983ddb83915fc56bd83954acece65096bfa81258983ddb83915fc56bd8"
-      )
-      expect(
-        script.compute_hash
-      ).to eq api._compute_script_hash(script)
-    end
-  end
-
   context "calculate bytesize" do
     let(:code_hash) { "0x9e3b3557f11b2b3532ce352bfe8017e9fd11d154c4c7f9b7aaaa1e621b539a08" }
     let(:args) { "0x36c329ed630d6ce750712a477543672adab57f4c" }

--- a/spec/ckb/types/transaction_spec.rb
+++ b/spec/ckb/types/transaction_spec.rb
@@ -356,45 +356,5 @@ RSpec.describe CKB::Types::Transaction do
         tx.compute_hash
       ).to eq tx.hash
     end
-
-    context "compared with rpc result" do
-      before do
-        skip "not call rpc" if ENV["SKIP_RPC_TESTS"]
-      end
-
-      let(:api) { CKB::API.new }
-
-      it "should build correct hash for specific transaction" do
-        tx = CKB::Types::Transaction.from_h(specific_tx_h)
-
-        expect(
-          tx.compute_hash
-        ).to eq api._compute_transaction_hash(tx)
-      end
-
-      it "should build correct hash when tx has one cell_deps" do
-        tx = CKB::Types::Transaction.from_h(one_cell_dep_tx_h)
-
-        expect(
-          tx.compute_hash
-        ).to eq api._compute_transaction_hash(tx)
-      end
-
-      it "should build correct hash when tx has multiple cell_deps" do
-        tx = CKB::Types::Transaction.from_h(multiple_cell_dep_tx_h)
-
-        expect(
-          tx.compute_hash
-        ).to eq api._compute_transaction_hash(tx)
-      end
-
-      it "should build correct hash when has type script" do
-        tx = CKB::Types::Transaction.from_h(has_type_script_tx_h)
-
-        expect(
-          tx.compute_hash
-        ).to eq api._compute_transaction_hash(tx)
-      end
-    end
   end
 end


### PR DESCRIPTION
# [v0.40.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.39.0...v0.40.0) (2021-03-10)


### Features

* add serialized_size_without_uncle_proposals ([43f5077](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/43f5077))
* deprecate get_cellbase_output_capacity_details and get_peers_state RPC ([2475550](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/2475550))


### Performance Improvements

* byte32 serializer ([9574a5e](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/9574a5e))
* bytes serializer ([9193fc9](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/9193fc9))
* output data serializer ([5c8e82e](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/5c8e82e))

