### PR TITLE
chore: upgrade net-http-persistent to 4.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ckb-sdk-ruby (0.40.0)
       bitcoin-secp256k1 (~> 0.5.2)
-      net-http-persistent (~> 3.1.0)
+      net-http-persistent (~> 4.0.1)
       rbnacl (~> 7.1.1)
 
 GEM
@@ -18,7 +18,7 @@ GEM
     ffi (1.15.0)
     jaro_winkler (1.5.2)
     method_source (0.9.2)
-    net-http-persistent (3.1.0)
+    net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
     parallel (1.17.0)
     parser (2.6.3.0)

--- a/ckb-sdk-ruby.gemspec
+++ b/ckb-sdk-ruby.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-performance"
   spec.add_development_dependency "pry", "~> 0.12.2"
 
-  spec.add_dependency "net-http-persistent", "~> 3.1.0"
+  spec.add_dependency "net-http-persistent", "~> 4.0.1"
   spec.add_dependency "rbnacl", "~> 7.1.1"
   spec.add_dependency "bitcoin-secp256k1", "~> 0.5.2"
 end


### PR DESCRIPTION
support Ruby 3.0.0