### PR TITLE
Rc/v0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# [v0.41.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.40.0...v0.41.0) (2021-05-06)
+
+
+### Features
+
+* add generate_block_with_template RPC ([311a8d1](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/311a8d1))
+* implement get_cells_capacity api ([a4ade40](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/a4ade40))
+* support search key filter ([50d7ebb](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/50d7ebb))
+
+
+
 # [v0.40.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.39.0...v0.40.0) (2021-03-10)
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ckb-sdk-ruby (0.40.0)
+    ckb-sdk-ruby (0.41.0)
       bitcoin-secp256k1 (~> 0.5.2)
       net-http-persistent (~> 4.0.1)
       rbnacl (~> 7.1.1)
@@ -13,7 +13,7 @@ GEM
     bitcoin-secp256k1 (0.5.2)
       ffi (>= 1.9.25)
     coderay (1.1.2)
-    connection_pool (2.2.3)
+    connection_pool (2.2.5)
     diff-lcs (1.3)
     ffi (1.15.0)
     jaro_winkler (1.5.2)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,14 +1,8 @@
-# [v0.40.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.39.0...v0.40.0) (2021-03-10)
+# [v0.41.0](https://github.com/nervosnetwork/ckb-sdk-ruby/compare/v0.40.0...v0.41.0) (2021-05-06)
 
 
 ### Features
 
-* add serialized_size_without_uncle_proposals ([43f5077](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/43f5077))
-* deprecate get_cellbase_output_capacity_details and get_peers_state RPC ([2475550](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/2475550))
-
-
-### Performance Improvements
-
-* byte32 serializer ([9574a5e](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/9574a5e))
-* bytes serializer ([9193fc9](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/9193fc9))
-* output data serializer ([5c8e82e](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/5c8e82e))
+* add generate_block_with_template RPC ([311a8d1](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/311a8d1))
+* implement get_cells_capacity api ([a4ade40](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/a4ade40))
+* support search key filter ([50d7ebb](https://github.com/nervosnetwork/ckb-sdk-ruby/commit/50d7ebb))

--- a/lib/ckb/api.rb
+++ b/lib/ckb/api.rb
@@ -341,6 +341,13 @@ module CKB
       rpc.clear_banned_addresses
     end
 
+
+    # @param block_template [CKB::Types::BlockTemplate]
+    # @return block_hash [string]
+    def generate_block_with_template(block_template)
+      rpc.generate_block_with_template(block_template.to_h)
+    end
+
     def inspect
       "\#<API@#{rpc.uri}>"
     end

--- a/lib/ckb/types/block_template.rb
+++ b/lib/ckb/types/block_template.rb
@@ -70,7 +70,7 @@ module CKB
           transactions: transactions.map(&:to_h),
           proposals: proposals,
           cellbase: cellbase.to_h,
-          work_id: work_id,
+          work_id: Utils.to_hex(work_id),
           dao: dao
         }
       end

--- a/lib/ckb/version.rb
+++ b/lib/ckb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CKB
-  VERSION = "0.40.0"
+  VERSION = "0.41.0"
 end

--- a/spec/ckb/api_spec.rb
+++ b/spec/ckb/api_spec.rb
@@ -351,6 +351,12 @@ RSpec.describe CKB::API do
       result = api.submit_block(work_id: "test", raw_block_h: block.to_raw_block_h)
       expect(result).to be_a(String)
     end
+
+    it "generate_block_with_template should return block hash" do
+	    block_template = api.get_block_template
+	    result = api.generate_block_with_template(block_template)
+	    expect(result).to be_a(String)
+    end
   end
 
   context "batch request" do

--- a/spec/ckb/types/block_template_spec.rb
+++ b/spec/ckb/types/block_template_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CKB::Types::BlockTemplate do
                  ["0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df201",
                   "0x3954acece65096bfa81258983ddb83915fc56bd8"]}]},
         :hash=>"0x6d6e478ae632208f4cc4120078bba78852e88ef136e8c5cc8c102b1e21c62dad"},
-     :work_id=>4,
+     :work_id=>"0x4",
      :dao=>"0xbcbcf54f7e4b090038b2d9a13464250018f37dd3985a000000f678cfa9890100"}
   end
 


### PR DESCRIPTION
# [v0.41.0](https://github.com/shaojunda/ckb-sdk-ruby/compare/v0.40.0...v0.41.0) (2021-05-06)


### Features

* add generate_block_with_template RPC ([311a8d1](https://github.com/shaojunda/ckb-sdk-ruby/commit/311a8d1))
* implement get_cells_capacity api ([a4ade40](https://github.com/shaojunda/ckb-sdk-ruby/commit/a4ade40))
* support search key filter ([50d7ebb](https://github.com/shaojunda/ckb-sdk-ruby/commit/50d7ebb))
