### PR TITLE
Replace bitcoin-secp256k1 with rbsecp256k1 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 
 # rspec failure tracking
 .rspec_status
+*.orig

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,27 +2,27 @@ PATH
   remote: .
   specs:
     ckb-sdk-ruby (0.103.0)
-      bitcoin-secp256k1 (~> 0.5.2)
       net-http-persistent (~> 4.0.1)
       rbnacl (~> 7.1.1)
+      rbsecp256k1 (~> 5.1.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    bitcoin-secp256k1 (0.5.2)
-      ffi (>= 1.9.25)
     coderay (1.1.2)
-    connection_pool (2.2.5)
+    connection_pool (2.3.0)
     diff-lcs (1.3)
     ffi (1.15.5)
     jaro_winkler (1.5.2)
     method_source (0.9.2)
+    mini_portile2 (2.8.1)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
     parallel (1.17.0)
     parser (2.6.3.0)
       ast (~> 2.4.0)
+    pkg-config (1.5.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -30,6 +30,10 @@ GEM
     rake (13.0.6)
     rbnacl (7.1.1)
       ffi
+    rbsecp256k1 (5.1.1)
+      mini_portile2 (~> 2.8)
+      pkg-config (~> 1.5)
+      rubyzip (~> 2.3)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -53,6 +57,7 @@ GEM
     rubocop-performance (1.3.0)
       rubocop (>= 0.68.0)
     ruby-progressbar (1.10.1)
+    rubyzip (2.3.2)
     unicode-display_width (1.6.0)
 
 PLATFORMS
@@ -71,4 +76,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   2.1.4
+   2.3.25

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Require Ruby 2.4 and above.
 sudo apt install libsodium-dev
 ```
 
-This SDK depends on the [bitcoin-secp256k1](https://github.com/cryptape/ruby-bitcoin-secp256k1) gem. You need to install libsecp256k1 with `--enable-module-recovery` (on which bitcoin-secp256k1 depends) manually. Follow [this](https://github.com/cryptape/ruby-bitcoin-secp256k1#prerequisite) to do so.
+This SDK depends on the [rbsecp256k1](https://github.com/etscrivner/rbsecp256k1) gem. You need to install libsecp256k1. Follow [this](https://github.com/etscrivner/rbsecp256k1#requirements) to do so.
 
 ### macOS
 

--- a/ckb-sdk-ruby.gemspec
+++ b/ckb-sdk-ruby.gemspec
@@ -44,5 +44,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "net-http-persistent", "~> 4.0.1"
   spec.add_dependency "rbnacl", "~> 7.1.1"
-  spec.add_dependency "bitcoin-secp256k1", "~> 0.5.2"
+  spec.add_dependency "rbsecp256k1", "~> 5.1.1"
 end

--- a/lib/ckb/key.rb
+++ b/lib/ckb/key.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "securerandom"
-require "secp256k1"
+require "rbsecp256k1"
 
 module CKB
   class Key
@@ -9,38 +9,38 @@ module CKB
 
     # @param privkey [String] hex string
     def initialize(privkey)
+      @context = Secp256k1::Context.create
       raise ArgumentError, "invalid privkey!" unless privkey.instance_of?(String) && privkey.size == 66
 
       raise ArgumentError, "invalid hex string!" unless CKB::Utils.valid_hex_string?(privkey)
 
       @privkey = privkey
+      @privkey_bin = Utils.hex_to_bin(privkey)
 
       begin
-        @pubkey = self.class.pubkey(@privkey)
-      rescue Secp256k1::AssertError
-        raise ArgumentError, "invalid privkey!"
+        @key_pair = @context.key_pair_from_private_key(@privkey_bin)
+        @pubkey = Utils.bin_to_hex @key_pair.public_key.compressed
+      rescue Secp256k1::Error => e
+        if e.message == 'invalid private key data'
+          raise ArgumentError, "invalid privkey!"
+        else
+          raise e
+        end
       end
     end
 
     # @param data [String] hex string
     # @return [String] signature in hex string
     def sign(data)
-      privkey_bin = Utils.hex_to_bin(privkey)
-      secp_key = Secp256k1::PrivateKey.new(privkey: privkey_bin)
-      signature_bin = secp_key.ecdsa_serialize(
-        secp_key.ecdsa_sign(Utils.hex_to_bin(data), raw: true)
-      )
-      Utils.bin_to_hex(signature_bin)
+      signature_bin = @context.sign(@key_pair.private_key, Utils.hex_to_bin(data))
+      Utils.bin_to_hex(signature_bin.der_encoded)
     end
 
     # @param data [String] hex string
     # @return [String] signature in hex string
     def sign_recoverable(data)
-      privkey_bin = Utils.hex_to_bin(privkey)
-      secp_key = Secp256k1::PrivateKey.new(privkey: privkey_bin)
-      signature_bin, recid = secp_key.ecdsa_recoverable_serialize(
-        secp_key.ecdsa_sign_recoverable(Utils.hex_to_bin(data), raw: true)
-      )
+      signature = @context.sign_recoverable(@key_pair.private_key, Utils.hex_to_bin(data))
+      signature_bin, recid = signature.compact
       Utils.bin_to_hex(signature_bin + [recid].pack("C*"))
     end
 
@@ -54,8 +54,8 @@ module CKB
 
     def self.pubkey(privkey)
       privkey_bin = [privkey[2..-1]].pack("H*")
-      pubkey_bin = Secp256k1::PrivateKey.new(privkey: privkey_bin).pubkey.serialize
-      Utils.bin_to_hex(pubkey_bin)
+      pubkey_bin = Secp256k1::PrivateKey.from_data(privkey_bin)
+      Utils.bin_to_hex(pubkey_bin.compressed)
     end
 
     def self.blake160(pubkey)

--- a/lib/ckb/key.rb
+++ b/lib/ckb/key.rb
@@ -9,13 +9,13 @@ module CKB
 
     # @param privkey [String] hex string
     def initialize(privkey)
-      @context = Secp256k1::Context.create
       raise ArgumentError, "invalid privkey!" unless privkey.instance_of?(String) && privkey.size == 66
 
       raise ArgumentError, "invalid hex string!" unless CKB::Utils.valid_hex_string?(privkey)
 
       @privkey = privkey
       @privkey_bin = Utils.hex_to_bin(privkey)
+      @context = Secp256k1::Context.create
 
       begin
         @key_pair = @context.key_pair_from_private_key(@privkey_bin)
@@ -53,9 +53,10 @@ module CKB
     end
 
     def self.pubkey(privkey)
-      privkey_bin = [privkey[2..-1]].pack("H*")
-      pubkey_bin = Secp256k1::PrivateKey.from_data(privkey_bin)
-      Utils.bin_to_hex(pubkey_bin.compressed)
+      context = Secp256k1::Context.create
+      privkey_bin = Utils.hex_to_bin(privkey)
+      key_pair = context.key_pair_from_private_key(privkey_bin)
+      pubkey = Utils.bin_to_hex(key_pair.public_key.compressed)
     end
 
     def self.blake160(pubkey)

--- a/lib/ckb/lock_handlers/single_sign_handler.rb
+++ b/lib/ckb/lock_handlers/single_sign_handler.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require "secp256k1"
+require "rbsecp256k1"
 
 module CKB
   module LockHandlers


### PR DESCRIPTION
The `bitcoin-secp256k1` gem has been archived for a long time.
And I cannot setup this gem on my macOS.
So we shall replace it with the actively-maintained gem `rbsecp256k1`