### PR TITLE
Refactor: use DEFAULT_URL for indexer as default

### DIFF
--- a/lib/ckb/indexer/api.rb
+++ b/lib/ckb/indexer/api.rb
@@ -7,7 +7,7 @@ module CKB
 
       DEFAULT_LIMIT = 1000
 
-      def initialize(indexer_host = CKB::RPC::DEFAULT_INDEXER_URL, timeout_config = {})
+      def initialize(indexer_host = CKB::RPC::DEFAULT_URL, timeout_config = {})
         @rpc = CKB::RPC.new(host: indexer_host, timeout_config: timeout_config)
       end
 

--- a/lib/ckb/rpc.rb
+++ b/lib/ckb/rpc.rb
@@ -25,7 +25,6 @@ module CKB
     attr_reader :uri, :http
 
     DEFAULT_URL = "http://localhost:8114"
-    DEFAULT_INDEXER_URL = "http://localhost:8116"
 
     def initialize(host: DEFAULT_URL, timeout_config: {})
       @uri = URI(host)


### PR DESCRIPTION
Now indexer is also using `http://localhost:8114` as default.