### PR TITLE
Fix default output validator

### DIFF
--- a/lib/ckb/wallet.rb
+++ b/lib/ckb/wallet.rb
@@ -128,7 +128,7 @@ module CKB
     # @param data [String] "0x..."
     # @param key [CKB::Key | String] Key or private key hex string
     # @param fee [Integer] transaction fee, in shannon
-    def send_capacity(target_address, capacity, data = "0x", key: nil, fee: 0, outputs_validator: "default", from_block_number: 0)
+    def send_capacity(target_address, capacity, data = "0x", key: nil, fee: 0, outputs_validator: "passthrough", from_block_number: 0)
       tx = generate_tx(target_address, capacity, data, key: key, fee: fee, from_block_number: from_block_number)
       send_transaction(tx, outputs_validator)
     end
@@ -359,7 +359,7 @@ args = #{lock.args}
     private
 
     # @param transaction [CKB::Transaction]
-    def send_transaction(transaction, outputs_validator = "default")
+    def send_transaction(transaction, outputs_validator = "passthrough")
       api.send_transaction(transaction, outputs_validator)
     end
 


### PR DESCRIPTION
### Type `OutputsValidator`
Transaction output validators that prevent common mistakes.

It's an enum value from one of:
  - passthrough : the default validator, bypass output checking, thus allow any kind of transaction outputs.
  - well_known_scripts_only : restricts the lock script and type script usage, see more information on <https://github.com/nervosnetwork/ckb/wiki/Transaction-%C2%BB-Default-Outputs-Validator>